### PR TITLE
v0.13

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# ========================================================
+# = .gitignore - Specifies intentionally untracked files for Git
+# ========================================================
 # Python
 __pycache__/
 *.pyc
@@ -15,6 +18,10 @@ pip-delete-this-directory/
 .vscode/
 .git
 
+# Coverage reports
+.coverage
+htmlcov/
+
 # Flask
 instance/ # For Flask instance folder, might contain sqlite DB or configs
 .flaskenv # For local environment variables
@@ -22,14 +29,10 @@ flask_app.log # Example log file
 
 # Docker
 *.env # If you use separate .env files for secrets
-volumes/ # If you mount volumes that contain user data or temporary files (e.g., your postgres_data)
-postgres_data/ # Specifically for your Docker volume
-# If you ever build images and don't want to track the build context directly
-# .dockerignore can also be used for Docker build context, but .gitignore handles Git
-# temp files created during build
 
 # Operating System Files
 .DS_Store
 Thumbs.db
 
 # Any other files that might be generated or contain sensitive info
+*.sqlite3

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,18 +1,38 @@
+# ========================================================
+# = Dockerfile - Defines the Docker image for RowErg Diary
+# ========================================================
 # syntax=docker/dockerfile:1.4
+
+# == Base Image ============================================
+# Use an official Python runtime as a parent image
 FROM python:3.12-slim-bookworm
 
+# == Working Directory ============================================
+# Set the working directory in the container
 WORKDIR /usr/src/app
 
+# == Dependencies ============================================
+# Copy the requirements file into the container
 COPY requirements.txt ./
 
+# Install any needed packages specified in requirements.txt
 RUN pip install --no-cache-dir -r requirements.txt
 
+# == Application Code ============================================
+# Copy the current directory contents into the container at /usr/src/app
 COPY . .
 
+# == Network Configuration ============================================
+# Make port 5000 available to the world outside this container
 EXPOSE 5000
 
+# == Environment Variables ============================================
+# Define environment variables for Flask
 ENV FLASK_APP=app.py
 ENV FLASK_RUN_HOST=0.0.0.0
+# Ensure Python output is sent straight to terminal without being buffered
 ENV PYTHONUNBUFFERED=1
 
+# == Execution Command ============================================
+# Run app.py when the container launches
 CMD ["flask", "run"]

--- a/app.py
+++ b/app.py
@@ -7,7 +7,7 @@ from views import home, submit_json_workout, workouts, details, database_managem
 # Import your utility functions and the context processor
 from utils import sidebar_stats_processor, format_total_seconds_human_readable, format_split_short, format_duration_ms # <--- IMPORT YOUR FILTERS
 
-__version__ = "0.1beta"
+__version__ = "0.12"
 
 def create_app(config_object=None):
     app = Flask(__name__)
@@ -29,6 +29,11 @@ def create_app(config_object=None):
     db.init_app(app)
 
     app.context_processor(sidebar_stats_processor)
+
+    # Add app version to context
+    @app.context_processor
+    def inject_version():
+        return dict(app_version=__version__)
 
     # <<< --- ADD THESE LINES TO REGISTER YOUR FILTERS --- >>>
     app.jinja_env.filters['format_total_seconds_human_readable'] = format_total_seconds_human_readable

--- a/app.py
+++ b/app.py
@@ -3,7 +3,7 @@ import os
 from flask import Flask
 from models import db
 # Import your views
-from views import home, submit_json_workout, workouts, details, database_management, dailysummary, workouts_by_date
+from views import home, submit_json_workout, workouts, details, database_management, dailysummary, workouts_by_date, submit_manual_workout
 # Import your utility functions and the context processor
 from utils import sidebar_stats_processor, format_total_seconds_human_readable, format_split_short, format_duration_ms # <--- IMPORT YOUR FILTERS
 
@@ -49,6 +49,7 @@ def create_app(config_object=None):
         database_management.register_routes(app)
         dailysummary.register_routes(app)
         workouts_by_date.register_routes(app)
+        submit_manual_workout.register_routes(app)
 
     return app
 

--- a/app.py
+++ b/app.py
@@ -8,7 +8,7 @@ from models import db
 # - View and Utility Imports
 #---------------------------------------------------------
 # Import application views
-from views import home, submit_json_workout, workouts, details, database_management, dailysummary, workouts_by_date, submit_manual_workout
+from views import home, submit_json_workout, workouts, details, database_management, dailysummary, weeklysummary, monthlysummary, yearlysummary, workouts_by_date, submit_manual_workout, workouts_by_week, workouts_by_month, workouts_by_year # Added workouts_by_year
 # Import utility functions and context processors
 from utils import sidebar_stats_processor, format_total_seconds_human_readable, format_split_short, format_duration_ms
 
@@ -66,7 +66,13 @@ def create_app(config_object=None):
         details.register_routes(app) # Registers routes for workout details page
         database_management.register_routes(app) # Registers routes for database management tasks
         dailysummary.register_routes(app) # Registers routes for daily summary page
+        weeklysummary.register_routes(app) # Registers routes for weekly summary page
+        monthlysummary.register_routes(app) # Registers routes for monthly summary page
+        yearlysummary.register_routes(app) # Registers routes for yearly summary page
         workouts_by_date.register_routes(app) # Registers routes for viewing workouts by specific date
+        workouts_by_week.register_routes(app) # Registers routes for viewing workouts by specific week
+        workouts_by_month.register_routes(app) # Registers routes for viewing workouts by specific month
+        workouts_by_year.register_routes(app) # Registers routes for viewing workouts by specific year
         submit_manual_workout.register_routes(app) # Registers routes for submitting manual workouts
 
     return app

--- a/app.py
+++ b/app.py
@@ -1,64 +1,81 @@
-# app.py
+# ========================================================
+# = app.py - Main Flask application setup
+# ========================================================
 import os
 from flask import Flask
 from models import db
-# Import your views
+# --------------------------------------------------------
+# - View and Utility Imports
+#---------------------------------------------------------
+# Import application views
 from views import home, submit_json_workout, workouts, details, database_management, dailysummary, workouts_by_date, submit_manual_workout
-# Import your utility functions and the context processor
-from utils import sidebar_stats_processor, format_total_seconds_human_readable, format_split_short, format_duration_ms # <--- IMPORT YOUR FILTERS
+# Import utility functions and context processors
+from utils import sidebar_stats_processor, format_total_seconds_human_readable, format_split_short, format_duration_ms
 
+# --------------------------------------------------------
+# - Application Version
+#---------------------------------------------------------
 __version__ = "0.12"
 
+# --------------------------------------------------------
+# - Application Factory Function
+#---------------------------------------------------------
 def create_app(config_object=None):
+    # == Flask App Initialization ============================================
     app = Flask(__name__)
 
-    # Configuration
-    app.config['MAX_CONTENT_LENGTH'] = 16 * 1024 * 1024
-    app.secret_key = os.environ.get('FLASK_SECRET_KEY', 'your_default_secret_key')
+    # == Configuration Settings ============================================
+    # -- General Flask Configuration -------------------
+    app.config['MAX_CONTENT_LENGTH'] = 16 * 1024 * 1024 # Max content length for uploads
+    app.config['SECRET_KEY'] = os.environ.get('FLASK_SECRET_KEY', 'your_default_secret_key') # Secret key for session management
+    app.config['PER_PAGE'] = int(os.environ.get('PER_PAGE', '10')) # Items per page for pagination
 
-    DB_USER = os.environ.get('POSTGRES_USER')
-    DB_PASSWORD = os.environ.get('POSTGRES_PASSWORD')
-    DB_NAME = os.environ.get('POSTGRES_DB')
-    DB_HOST = os.environ.get('POSTGRES_HOST', 'db')
+    # -- Database Configuration -------------------
+    DB_USER = os.environ.get('POSTGRES_USER') # PostgreSQL username
+    DB_PASSWORD = os.environ.get('POSTGRES_PASSWORD') # PostgreSQL password
+    DB_NAME = os.environ.get('POSTGRES_DB') # PostgreSQL database name
+    DB_HOST = os.environ.get('POSTGRES_HOST', 'db') # PostgreSQL host
 
-    app.config['PER_PAGE'] = int(os.environ.get('PER_PAGE', '10'))
-
-    app.config['SQLALCHEMY_DATABASE_URI'] = f'postgresql://{DB_USER}:{DB_PASSWORD}@{DB_HOST}:5432/{DB_NAME}'
-    app.config['SQLALCHEMY_TRACK_MODIFICATIONS'] = False
+    app.config['SQLALCHEMY_DATABASE_URI'] = f'postgresql://{DB_USER}:{DB_PASSWORD}@{DB_HOST}:5432/{DB_NAME}' # SQLAlchemy database URI
+    app.config['SQLALCHEMY_TRACK_MODIFICATIONS'] = False # Disable SQLAlchemy event system
     
-    db.init_app(app)
+    # == Database Initialization ============================================
+    db.init_app(app) # Initialize SQLAlchemy with the Flask app
 
-    app.context_processor(sidebar_stats_processor)
+    # == Context Processors ============================================
+    app.context_processor(sidebar_stats_processor) # Register sidebar stats processor
 
-    # Add app version to context
+    # == Inject App Version into Templates ============================================
     @app.context_processor
     def inject_version():
+        # Makes app_version available in all templates
         return dict(app_version=__version__)
 
-    # <<< --- ADD THESE LINES TO REGISTER YOUR FILTERS --- >>>
+    # == Jinja Filters ============================================
+    # Register custom Jinja2 filters for template formatting
     app.jinja_env.filters['format_total_seconds_human_readable'] = format_total_seconds_human_readable
     app.jinja_env.filters['format_split_short'] = format_split_short
     app.jinja_env.filters['format_split_ms'] = format_duration_ms 
-    #   ^ You can choose the name you want to use in the template.
-    #     e.g., if you used {{ value | format_split_ms }} in the template, this is correct.
-    #     If you used {{ value | format_duration_ms }} in the template, then use:
-    #     app.jinja_env.filters['format_duration_ms'] = format_duration_ms
-
-
-    # Register routes
+    
+    # == Route Registration ============================================
+    # Register blueprints and routes from view modules
     with app.app_context():
-        home.register_routes(app)
-        submit_json_workout.register_routes(app)
-        workouts.register_routes(app)
-        details.register_routes(app)
-        database_management.register_routes(app)
-        dailysummary.register_routes(app)
-        workouts_by_date.register_routes(app)
-        submit_manual_workout.register_routes(app)
+        home.register_routes(app) # Registers routes for home page
+        submit_json_workout.register_routes(app) # Registers routes for submitting JSON workouts
+        workouts.register_routes(app) # Registers routes for displaying workouts list
+        details.register_routes(app) # Registers routes for workout details page
+        database_management.register_routes(app) # Registers routes for database management tasks
+        dailysummary.register_routes(app) # Registers routes for daily summary page
+        workouts_by_date.register_routes(app) # Registers routes for viewing workouts by specific date
+        submit_manual_workout.register_routes(app) # Registers routes for submitting manual workouts
 
     return app
 
+# --------------------------------------------------------
+# - Main Execution Block
+#---------------------------------------------------------
 if __name__ == '__main__':
-    # Make sure to create the app instance if running directly
-    app = create_app() # <--- Ensure app is created
+    # Ensure the Flask app instance is created when running directly
+    app = create_app() 
+    # Run the Flask development server
     app.run(host='0.0.0.0', port=5000, debug=True)

--- a/models.py
+++ b/models.py
@@ -21,6 +21,7 @@ class Workout(db.Model):
     duration_seconds = db.Column(db.Numeric, nullable=True)
     total_distance_meters = db.Column(db.Numeric, nullable=True)
     average_split_seconds_500m = db.Column(db.Numeric, nullable=True)
+    total_isoreps = db.Column(db.Numeric, nullable=True) # <--- NEW COLUMN ADDED HERE
     
     workout_samples = db.relationship('WorkoutSample', backref='workout', lazy='select', cascade="all, delete-orphan")
     heart_rate_samples = db.relationship('HeartRateSample', backref='workout', lazy='select', cascade="all, delete-orphan")

--- a/models.py
+++ b/models.py
@@ -1,50 +1,82 @@
-# models.py
+# ========================================================
+# = models.py - Database schema definition
+# ========================================================
 from flask_sqlalchemy import SQLAlchemy
-# from decimal import Decimal # Not directly used in models
 
+# --------------------------------------------------------
+# - SQLAlchemy Database Instance
+#---------------------------------------------------------
+# Global SQLAlchemy database instance
 db = SQLAlchemy()
 
+# --------------------------------------------------------
+# - EquipmentType Model
+#---------------------------------------------------------
+# Defines the types of workout equipment
 class EquipmentType(db.Model):
     __tablename__ = 'equipment_types'
     equipment_type_id = db.Column(db.Integer, primary_key=True, autoincrement=True)
     name = db.Column(db.String(255), nullable=False, unique=True)
+    # -- Relationships -------------------
     workouts = db.relationship('Workout', backref='equipment_type_ref', lazy=True)
 
+# --------------------------------------------------------
+# - Workout Model
+#---------------------------------------------------------
+# Represents a single workout session
 class Workout(db.Model):
     __tablename__ = 'workouts'
-    workout_id = db.Column(db.Integer, primary_key=True, autoincrement=True)
-    cardio_log_id = db.Column(db.String(255), nullable=False, unique=True)
-    equipment_type_id = db.Column(db.Integer, db.ForeignKey('equipment_types.equipment_type_id'))
-    workout_name = db.Column(db.String(255))
-    workout_date = db.Column(db.Date, nullable=False)
-    target_description = db.Column(db.String(100))
-    duration_seconds = db.Column(db.Numeric, nullable=True)
-    total_distance_meters = db.Column(db.Numeric, nullable=True)
-    average_split_seconds_500m = db.Column(db.Numeric, nullable=True)
-    total_isoreps = db.Column(db.Numeric, nullable=True)
-    notes = db.Column(db.Text, nullable=True) # <--- NEW COLUMN ADDED HERE
+    workout_id = db.Column(db.Integer, primary_key=True, autoincrement=True) # Primary key for the workout
+    cardio_log_id = db.Column(db.String(255), nullable=False, unique=True) # Unique identifier from the source cardio log (e.g., ErgData)
+    equipment_type_id = db.Column(db.Integer, db.ForeignKey('equipment_types.equipment_type_id')) # Foreign key linking to the equipment type used
+    workout_name = db.Column(db.String(255)) # User-defined name for the workout
+    workout_date = db.Column(db.Date, nullable=False) # Date the workout was performed
+    target_description = db.Column(db.String(100)) # Description of the workout target
+    duration_seconds = db.Column(db.Numeric, nullable=True) # Total duration of the workout in seconds
+    total_distance_meters = db.Column(db.Numeric, nullable=True) # Total distance covered in meters
+    average_split_seconds_500m = db.Column(db.Numeric, nullable=True) # Average split time per 500 meters, in seconds
+    total_isoreps = db.Column(db.Numeric, nullable=True) # Total isokinetic repetitions (specific to certain equipment)
+    notes = db.Column(db.Text, nullable=True) # User-provided notes for the workout
+    level = db.Column(db.Float, nullable=True) # User-defined difficulty level or intensity (float)
     
+    # -- Relationships -------------------
+    # Defines one-to-many relationships with detailed sample data
     workout_samples = db.relationship('WorkoutSample', backref='workout', lazy='select', cascade="all, delete-orphan")
     heart_rate_samples = db.relationship('HeartRateSample', backref='workout', lazy='select', cascade="all, delete-orphan")
     workout_hr_zones = db.relationship('WorkoutHRZone', backref='workout', lazy='select', cascade="all, delete-orphan")
 
+    # -- Representation -------------------
     def __repr__(self):
+        # String representation for debugging and logging
         return f"<Workout {self.workout_id} - {self.workout_name} on {self.workout_date}>"
 
+# --------------------------------------------------------
+# - MetricDescriptor Model
+#---------------------------------------------------------
+# Describes a type of metric recorded during a workout (e.g., 'Pace', 'Power')
 class MetricDescriptor(db.Model):
     __tablename__ = 'metric_descriptors'
     metric_descriptor_id = db.Column(db.Integer, primary_key=True, autoincrement=True)
     metric_name = db.Column(db.String(100), nullable=False)
     unit_of_measure = db.Column(db.String(50), nullable=True)
 
+    # == Table Arguments ============================================
+    # Ensures that each metric name and unit combination is unique
     __table_args__ = (
         db.UniqueConstraint('metric_name', 'unit_of_measure', name='uq_metric_descriptor_name_unit'),
     )
+    # -- Relationships -------------------
     samples = db.relationship('WorkoutSample', backref='metric_descriptor_ref', lazy='select')
 
+    # -- Representation -------------------
     def __repr__(self):
+        # String representation for debugging and logging
         return f"<MetricDescriptor {self.metric_descriptor_id} - {self.metric_name} ({self.unit_of_measure})>"
 
+# --------------------------------------------------------
+# - WorkoutSample Model
+#---------------------------------------------------------
+# Stores individual data points (samples) for a workout metric over time
 class WorkoutSample(db.Model):
     __tablename__ = 'workout_samples'
     sample_id = db.Column(db.BigInteger, primary_key=True, autoincrement=True)
@@ -53,6 +85,10 @@ class WorkoutSample(db.Model):
     time_offset_seconds = db.Column(db.Integer, nullable=False)
     value = db.Column(db.Numeric, nullable=False)
 
+# --------------------------------------------------------
+# - HeartRateSample Model
+#---------------------------------------------------------
+# Stores individual heart rate samples for a workout over time
 class HeartRateSample(db.Model):
     __tablename__ = 'heart_rate_samples'
     hr_sample_id = db.Column(db.BigInteger, primary_key=True, autoincrement=True)
@@ -60,6 +96,10 @@ class HeartRateSample(db.Model):
     time_offset_seconds = db.Column(db.Integer, nullable=False)
     heart_rate_bpm = db.Column(db.Integer)
 
+# --------------------------------------------------------
+# - WorkoutHRZone Model
+#---------------------------------------------------------
+# Stores time spent in different heart rate zones for a workout
 class WorkoutHRZone(db.Model):
     __tablename__ = 'workout_hr_zones'
     workout_hr_zone_id = db.Column(db.Integer, primary_key=True, autoincrement=True)

--- a/models.py
+++ b/models.py
@@ -40,14 +40,12 @@ class Workout(db.Model):
     level = db.Column(db.Float, nullable=True) # User-defined difficulty level or intensity (float)
     
     # -- Relationships -------------------
-    # Defines one-to-many relationships with detailed sample data
     workout_samples = db.relationship('WorkoutSample', backref='workout', lazy='select', cascade="all, delete-orphan")
     heart_rate_samples = db.relationship('HeartRateSample', backref='workout', lazy='select', cascade="all, delete-orphan")
     workout_hr_zones = db.relationship('WorkoutHRZone', backref='workout', lazy='select', cascade="all, delete-orphan")
 
     # -- Representation -------------------
     def __repr__(self):
-        # String representation for debugging and logging
         return f"<Workout {self.workout_id} - {self.workout_name} on {self.workout_date}>"
 
 # --------------------------------------------------------
@@ -70,7 +68,6 @@ class MetricDescriptor(db.Model):
 
     # -- Representation -------------------
     def __repr__(self):
-        # String representation for debugging and logging
         return f"<MetricDescriptor {self.metric_descriptor_id} - {self.metric_name} ({self.unit_of_measure})>"
 
 # --------------------------------------------------------

--- a/models.py
+++ b/models.py
@@ -21,7 +21,8 @@ class Workout(db.Model):
     duration_seconds = db.Column(db.Numeric, nullable=True)
     total_distance_meters = db.Column(db.Numeric, nullable=True)
     average_split_seconds_500m = db.Column(db.Numeric, nullable=True)
-    total_isoreps = db.Column(db.Numeric, nullable=True) # <--- NEW COLUMN ADDED HERE
+    total_isoreps = db.Column(db.Numeric, nullable=True)
+    notes = db.Column(db.Text, nullable=True) # <--- NEW COLUMN ADDED HERE
     
     workout_samples = db.relationship('WorkoutSample', backref='workout', lazy='select', cascade="all, delete-orphan")
     heart_rate_samples = db.relationship('HeartRateSample', backref='workout', lazy='select', cascade="all, delete-orphan")
@@ -33,17 +34,12 @@ class Workout(db.Model):
 class MetricDescriptor(db.Model):
     __tablename__ = 'metric_descriptors'
     metric_descriptor_id = db.Column(db.Integer, primary_key=True, autoincrement=True)
-    # NO workout_id FOREIGN KEY HERE:
-    # Removed: workout_id = db.Column(db.Integer, db.ForeignKey('workouts.workout_id'), nullable=False) 
-    # Removed: json_index = db.Column(db.Integer, nullable=False)
     metric_name = db.Column(db.String(100), nullable=False)
-    unit_of_measure = db.Column(db.String(50), nullable=True) # Made unit_of_measure nullable
+    unit_of_measure = db.Column(db.String(50), nullable=True)
 
     __table_args__ = (
         db.UniqueConstraint('metric_name', 'unit_of_measure', name='uq_metric_descriptor_name_unit'),
     )
-    # This relationship means "many samples can point to one metric descriptor"
-    # It does NOT mean a descriptor owns samples. Samples are owned by Workouts.
     samples = db.relationship('WorkoutSample', backref='metric_descriptor_ref', lazy='select')
 
     def __repr__(self):
@@ -52,7 +48,7 @@ class MetricDescriptor(db.Model):
 class WorkoutSample(db.Model):
     __tablename__ = 'workout_samples'
     sample_id = db.Column(db.BigInteger, primary_key=True, autoincrement=True)
-    workout_id = db.Column(db.Integer, db.ForeignKey('workouts.workout_id', ondelete='CASCADE'), nullable=False) # Added ondelete='CASCADE'
+    workout_id = db.Column(db.Integer, db.ForeignKey('workouts.workout_id', ondelete='CASCADE'), nullable=False)
     metric_descriptor_id = db.Column(db.Integer, db.ForeignKey('metric_descriptors.metric_descriptor_id'), nullable=False)
     time_offset_seconds = db.Column(db.Integer, nullable=False)
     value = db.Column(db.Numeric, nullable=False)
@@ -60,14 +56,14 @@ class WorkoutSample(db.Model):
 class HeartRateSample(db.Model):
     __tablename__ = 'heart_rate_samples'
     hr_sample_id = db.Column(db.BigInteger, primary_key=True, autoincrement=True)
-    workout_id = db.Column(db.Integer, db.ForeignKey('workouts.workout_id', ondelete='CASCADE'), nullable=False) # Added ondelete='CASCADE'
+    workout_id = db.Column(db.Integer, db.ForeignKey('workouts.workout_id', ondelete='CASCADE'), nullable=False)
     time_offset_seconds = db.Column(db.Integer, nullable=False)
     heart_rate_bpm = db.Column(db.Integer)
 
 class WorkoutHRZone(db.Model):
     __tablename__ = 'workout_hr_zones'
     workout_hr_zone_id = db.Column(db.Integer, primary_key=True, autoincrement=True)
-    workout_id = db.Column(db.Integer, db.ForeignKey('workouts.workout_id', ondelete='CASCADE'), nullable=False) # Added ondelete='CASCADE'
+    workout_id = db.Column(db.Integer, db.ForeignKey('workouts.workout_id', ondelete='CASCADE'), nullable=False)
     zone_name = db.Column(db.String(100), nullable=False)
     color_hex = db.Column(db.String(7))
     lower_bound_bpm = db.Column(db.Numeric)

--- a/roadmap.md
+++ b/roadmap.md
@@ -1,7 +1,6 @@
 # Roadmap
 - Database
-    - Store Total "IsoReps" in workout database
-    - Display IsoReps Everywhere
+    - The current templates (e.g., index.html, workouts.html, details.html, _sidebar.html, dailysummary.html, workouts_by_date.html) do not yet display the total_isoreps value
 - Adding backend functionality for the "Manual Workout Input" form.
 - Move Inline CSS from details.html
 - Enhanced Statistics & Dashboard Page
@@ -16,7 +15,6 @@
     - Add "Edit" and "Delete" buttons to the workout listings (e.g., in workouts.html, workouts_by_date.html, index.html).
 - Filtering and Sorting:
     - Workouts Page:
-        - Add dropdowns or input fields to filter by date range.
         - Add clickable table headers to sort by date, distance, duration, split.
     - Daily Summary Page:
         - Filter by year/month.

--- a/roadmap.md
+++ b/roadmap.md
@@ -34,4 +34,3 @@
 - Backup/Restore Database.
 - Concept2 Log API integration
     - autosync workouts
-- AVG Level setting to workouts

--- a/roadmap.md
+++ b/roadmap.md
@@ -16,8 +16,6 @@
 - Filtering and Sorting:
     - Workouts Page:
         - Add clickable table headers to sort by date, distance, duration, split.
-    - Daily Summary Page:
-        - Filter by year/month.
 - Weekly Summary
 - Monthly Summary
 - Yearly Summary
@@ -36,3 +34,4 @@
 - Backup/Restore Database.
 - Concept2 Log API integration
     - autosync workouts
+- AVG Level setting to workouts

--- a/static/css/mystyles.css
+++ b/static/css/mystyles.css
@@ -91,17 +91,40 @@
     flex-direction: column;
     gap: 6px;
 }
-#workoutInputForm div {
+/* New styles for horizontal field rows */
+.form-row-split {
     display: flex;
-    flex-direction: column;
-    margin-bottom: 4px;
+    gap: 10px; /* Space between the two fields on the same line */
+}/* Style for individual field groups within horizontal rows */
+.form-field-group {
+    flex: 1; /* Makes each field group take up equal space in the row */
+    /* Labels and inputs inside this div will naturally stack because they are display: block by default. */
 }
+#jsonInputForm label,
 #workoutInputForm label {
     font-weight: 600;
     margin-bottom: 2px;
     color: #3b4a6b;
     letter-spacing: 0.02em;
 }
+#jsonInputForm textarea,
+#workoutInputForm textarea {
+    padding: 6px 8px;
+    border: 1px solid #b3c6e7;
+    border-radius: 4px;
+    background: #f8fbff;
+    font-size: 1em;
+    color: #222;
+    transition: border 0.2s;
+    min-height: 2em;
+    resize: vertical;
+    width: 100%; /* Ensure it takes full width of its parent */
+    display: block; /* Important: ensure it behaves as a block element */
+}
+#jsonInputForm textarea {
+    min-height: 5em;
+}
+
 #workoutInputForm input[readonly],
 #workoutInputForm input[type="date"],
 #workoutInputForm input[type="text"],
@@ -114,6 +137,8 @@
     color: #222;
     transition: border 0.2s;
     height: 32px;
+    width: 100%; /* Ensure it takes full width of its parent */
+    display: block; /* Important: ensure it behaves as a block element */
 }
 #workoutInputForm input:focus {
     border-color: #6a8fd7;
@@ -129,6 +154,7 @@
     font-size: 1.05em;
     cursor: pointer;
     text-shadow: none;
+    width: 100%; /* Ensure button takes full width */
 }
 
 /* JSON Input Form */
@@ -142,7 +168,8 @@
     flex-direction: column;
     margin-bottom: 4px;
 }
-#jsonInputForm textarea:focus {
+#jsonInputForm textarea:focus,
+#workoutInputForm textarea:focus {
     border-color: #6a8fd7;
     outline: none;
 }

--- a/templates/_sidebar.html
+++ b/templates/_sidebar.html
@@ -1,45 +1,50 @@
-<!-- templates/_sidebar.html -->
+<!-- ======================================================== -->
+<!-- = _sidebar.html - Sidebar template for the application -->
+<!-- ======================================================== -->
 <div id="sidebar">
-    <!-- Logo -->
-        <h1 id="logo"><a href="{{ url_for('home') }}">Row Diary</a></h1>
-    <!-- Nav -->
-        <nav id="nav">
-            <ul>
-                <li class="{{ 'current' if request.path == url_for('home') else '' }}"><a href="{{ url_for('home') }}">Home</a></li>
-                <li class="{{ 'current' if request.path == url_for('workouts') else '' }}"><a href="{{ url_for('workouts') }}">Workouts</a></li>
-                <li class="{{ 'current' if request.path == url_for('dailysummary') else '' }}"><a href="{{ url_for('dailysummary') }}">Daily Summary</a></li>
-                <li><a href="/database/create">Database create</a></li>
-            </ul>
-        </nav>
-    <!-- Text -->
-        <section class="box text-style1">
-            <div class="inner">
-                <h3 style="text-align: center;">Total</h3>
-                <table class="sidebar-total-stats">
-                    <tbody>
-                        <tr>
-                            <td class="label">Rowed:</td>
-                            <td class="value">{{ '{:,.0f}'.format(sidebar_stats.overall_totals.meters) }} m</td>
-                        </tr>
-                        <tr>
-                            <td class="label">Duration:</td>
-                            <td class="value">
-                                {{ sidebar_stats.overall_totals.seconds | format_total_seconds_human_readable }}
-                            </td>
-                        </tr>
-                        <tr>
-                            <td class="label">Split:</td>
-                            <td class="value">
-                                {{ sidebar_stats.overall_totals.split | format_split_short }}
-                            </td>
-                        </tr>
-                    </tbody>
-                </table>
-            </div>
-        </section>
-    <!-- Copyright -->
-        <ul id="copyright">
-            <li><a href="http://github.com">RowErg Diary</a></li>
-            <li>ver. {{ app_version }}</li>
+    <!-- == Logo ============================================ -->
+    <h1 id="logo"><a href="{{ url_for('home') }}">Row Diary</a></h1> <!-- Site Logo and Link to Home -->
+
+    <!-- == Navigation Menu ============================================ -->
+    <nav id="nav">
+        <ul>
+            <li class="{{ 'current' if request.path == url_for('home') else '' }}"><a href="{{ url_for('home') }}">Home</a></li> <!-- Home Page Link -->
+            <li class="{{ 'current' if request.path == url_for('workouts') else '' }}"><a href="{{ url_for('workouts') }}">Workouts</a></li> <!-- Workouts List Link -->
+            <li class="{{ 'current' if request.path == url_for('dailysummary') else '' }}"><a href="{{ url_for('dailysummary') }}">Daily Summary</a></li> <!-- Daily Summary Link -->
+            <li><a href="/database/create">Database create</a></li> <!-- Link to Database Creation (Consider making this a proper endpoint) -->
         </ul>
+    </nav>
+
+    <!-- == Total Statistics Section ============================================ -->
+    <section class="box text-style1">
+        <div class="inner">
+            <h3 style="text-align: center;">Total</h3> <!-- Section Title -->
+            <table class="sidebar-total-stats">
+                <tbody>
+                    <tr>
+                        <td class="label">Rowed:</td> <!-- Total Distance Rowed Label -->
+                        <td class="value">{{ '{:,.0f}'.format(sidebar_stats.overall_totals.meters) }} m</td> <!-- Total Distance Value -->
+                    </tr>
+                    <tr>
+                        <td class="label">Duration:</td> <!-- Total Duration Label -->
+                        <td class="value">
+                            {{ sidebar_stats.overall_totals.seconds | format_total_seconds_human_readable }} <!-- Total Duration Value (Formatted) -->
+                        </td>
+                    </tr>
+                    <tr>
+                        <td class="label">Split:</td> <!-- Average Split Label -->
+                        <td class="value">
+                            {{ sidebar_stats.overall_totals.split | format_split_short }} <!-- Average Split Value (Formatted) -->
+                        </td>
+                    </tr>
+                </tbody>
+            </table>
+        </div>
+    </section>
+
+    <!-- == Copyright and Version Information ============================================ -->
+    <ul id="copyright">
+        <li><a href="http://github.com">RowErg Diary</a></li> <!-- Project Link -->
+        <li>ver. {{ app_version }}</li> <!-- Application Version -->
+    </ul>
 </div>

--- a/templates/_sidebar.html
+++ b/templates/_sidebar.html
@@ -11,7 +11,15 @@
             <li class="{{ 'current' if request.path == url_for('home') else '' }}"><a href="{{ url_for('home') }}">Home</a></li> <!-- Home Page Link -->
             <li class="{{ 'current' if request.path == url_for('workouts') else '' }}"><a href="{{ url_for('workouts') }}">Workouts</a></li> <!-- Workouts List Link -->
             <li class="{{ 'current' if request.path == url_for('dailysummary') else '' }}"><a href="{{ url_for('dailysummary') }}">Daily Summary</a></li> <!-- Daily Summary Link -->
+            <li class="{{ 'current' if request.path == url_for('weeklysummary') else '' }}"><a href="{{ url_for('weeklysummary') }}">Weekly Summary</a></li>
+            <li class="{{ 'current' if request.path == url_for('monthlysummary') else '' }}"><a href="{{ url_for('monthlysummary') }}">Monthly Summary</a></li>
+            <li class="{{ 'current' if request.path == url_for('yearlysummary') else '' }}"><a href="{{ url_for('yearlysummary') }}">Yearly Summary</a></li>
+
             <li><a href="/database/create">Database create</a></li> <!-- Link to Database Creation (Consider making this a proper endpoint) -->
+
+
+
+
         </ul>
     </nav>
 

--- a/templates/_sidebar.html
+++ b/templates/_sidebar.html
@@ -40,6 +40,6 @@
     <!-- Copyright -->
         <ul id="copyright">
             <li><a href="http://github.com">RowErg Diary</a></li>
-            <li>ver. 0.1beta</li>
+            <li>ver. {{ app_version }}</li>
         </ul>
 </div>

--- a/templates/_sidebar.html
+++ b/templates/_sidebar.html
@@ -9,7 +9,6 @@
                 <li class="{{ 'current' if request.path == url_for('workouts') else '' }}"><a href="{{ url_for('workouts') }}">Workouts</a></li>
                 <li class="{{ 'current' if request.path == url_for('dailysummary') else '' }}"><a href="{{ url_for('dailysummary') }}">Daily Summary</a></li>
                 <li><a href="/database/create">Database create</a></li>
-                <li><a href="/database/delete">Database delete</a></li>
             </ul>
         </nav>
     <!-- Text -->

--- a/templates/dailysummary.html
+++ b/templates/dailysummary.html
@@ -1,116 +1,124 @@
-<!-- templates/dailysummary.html -->
+<!-- ======================================================== -->
+<!-- = dailysummary.html - Template for displaying daily workout summaries -->
+<!-- ======================================================== -->
 <!DOCTYPE HTML>
 <html>
 	<head>
-		<title>Daily Workout Totals</title>
+		<title>Daily Workout Totals</title> <!-- Page Title -->
 		<meta charset="utf-8" />
 		<meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no" />
-		<link rel="icon" href="{{ url_for('static', filename='favicon.ico') }}">
-		<link rel="stylesheet" href="{{ url_for('static', filename='css/main.css') }}" />
-		<link rel="stylesheet" href="{{ url_for('static', filename='css/mystyles.css') }}" />
+		<link rel="icon" href="{{ url_for('static', filename='favicon.ico') }}"> <!-- Favicon Link -->
+		<link rel="stylesheet" href="{{ url_for('static', filename='css/main.css') }}" /> <!-- Main Stylesheet -->
+		<link rel="stylesheet" href="{{ url_for('static', filename='css/mystyles.css') }}" /> <!-- Custom Stylesheet -->
 	</head>
 	<body class="is-preload">
 
-		<!-- Content -->
-			<div id="content" class="custom-fullwidth">
-				<div class="inner">
-                    <h1 class="extra_h1">Daily Summary</h1>
-                    <hr class="extra_title_line">
-					<!-- flash messages -->
-						{% with messages = get_flashed_messages(with_categories=true) %}
-							{% if messages %}
-								<article class="box post post-excerpt">
-								{% for category, message in messages %}
-									<div class="box alert-{{ category }}" style="font-size: 1.3em; border: 1px solid; padding: 16px; margin-bottom: 20px; text-align: center;">
-										{{ message }}
-									</div>
-								{% endfor %}
-								</article>
-							{% endif %}
-						{% endwith %}
-					
-					<!-- Daily Totals Table -->
-						{% if dailysummary_display_data %}
-							<article class="box post post-excerpt">
-								<table>
-									<thead>
-										<tr>
-											<th>Date</th>
-											<th>Distance</th>
-											<th>Duration</th>
-											<th>Split</th>
-											<th>Actions</th>
-										</tr>
-									</thead>
-									<tbody>
-										{% for item_data in dailysummary_display_data %}
-										<tr>
-											<td>{{ item_data.day_date.strftime('%Y-%m-%d') if item_data.day_date else 'N/A' }}</td>
-											<td>{{ '{:,.0f}'.format(item_data.meters) }} m</td>
-											<td>
-                                                {{ item_data.seconds | format_total_seconds_human_readable }}
-                                            </td>
-											<td>
-                                                {{ item_data.split | format_split_short }}
-                                            </td>
-											<td>
-												<a href="{{ url_for('workouts_by_date', date_str=item_data.day_date.strftime('%Y-%m-%d')) }}">
-													<i class="fas fa-eye"></i> Details
-												</a>
-											</td>
-										</tr>
-										{% endfor %}
-									</tbody>
-								</table>
-							</article>
-						{% else %}								
-								<article class="box post post-excerpt">
-									<div class="box alert-info" style="font-size: 1.3em; border: 1px solid; padding: 16px; margin-bottom: 20px; text-align: center;">
-										No daily totals found.
-									</div>
-								</article>
-							<p></p>
-						{% endif %}
+		<!-- == Main Content Area ============================================ -->
+		<div id="content" class="custom-fullwidth">
+			<div class="inner">
+				<!-- -- Page Header ------------------- -->
+				<h1 class="extra_h1">Daily Summary</h1>
+				<hr class="extra_title_line">
 
-					<!-- Pagination -->
-					{% if dailysummary_pagination.pages > 1 %}
-						<div class="pagination">
-							{% if dailysummary_pagination.has_prev %}
-								<a href="{{ url_for('dailysummary_paginated', page_num=dailysummary_pagination.prev_num) }}"
-								   class="button previous">Previous Page</a>
-							{% else %}
-								<span class="button previous disabled" aria-disabled="true">Previous Page</span>
-							{% endif %}
-							
-							<div class="pages">
-								{% for page in dailysummary_pagination.iter_pages(left_edge=1, right_edge=1, left_current=2, right_current=2) %}
-									{% if page %}
-										<a href="{{ url_for('dailysummary_paginated', page_num=page) }}"
-										   class="{% if page == dailysummary_pagination.page %}active{% endif %}">{{ page }}</a>
-									{% else %}
-										<span>…</span>
-									{% endif %}
-								{% endfor %}
+				<!-- -- Flash Messages Section ------------------- -->
+				{% with messages = get_flashed_messages(with_categories=true) %}
+					{% if messages %}
+						<article class="box post post-excerpt">
+						{% for category, message in messages %}
+							<div class="box alert-{{ category }}" style="font-size: 1.3em; border: 1px solid; padding: 16px; margin-bottom: 20px; text-align: center;">
+								{{ message }} <!-- Display flash message -->
 							</div>
-							
-							{% if dailysummary_pagination.has_next %}
-								<a href="{{ url_for('dailysummary_paginated', page_num=dailysummary_pagination.next_num) }}"
-								   class="button next">Next Page</a>
-							{% else %}
-								<span class="button next disabled" aria-disabled="true">Next Page</span>
-							{% endif %}
-						</div>
+						{% endfor %}
+						</article>
 					{% endif %}
-				</div>
-			</div>
-		<!-- Sidebar -->
-			{% include '_sidebar.html' %}
+				{% endwith %}
+					
+				<!-- -- Daily Totals Table Section ------------------- -->
+				{% if dailysummary_display_data %} <!-- Check if there is data to display -->
+					<article class="box post post-excerpt">
+						<table>
+							<thead>
+								<tr>
+									<th>Date</th>
+									<th>Distance</th>
+									<th>Duration</th>
+									<th>Split</th>
+									<th>Actions</th>
+								</tr>
+							</thead>
+							<tbody>
+								{% for item_data in dailysummary_display_data %} <!-- Loop through each daily summary item -->
+								<tr>
+									<td>{{ item_data.day_date.strftime('%Y-%m-%d') if item_data.day_date else 'N/A' }}</td> <!-- Date of the summary -->
+									<td>{{ '{:,.0f}'.format(item_data.meters) }} m</td> <!-- Total distance for the day -->
+									<td>
+										{{ item_data.seconds | format_total_seconds_human_readable }} <!-- Total duration for the day -->
+									</td>
+									<td>
+										{{ item_data.split | format_split_short }} <!-- Average split for the day -->
+									</td>
+									<td>
+										<!-- Link to view detailed workouts for this specific date -->
+										<a href="{{ url_for('workouts_by_date', date_str=item_data.day_date.strftime('%Y-%m-%d')) }}">
+											<i class="fas fa-eye"></i> Details
+										</a>
+									</td>
+								</tr>
+								{% endfor %}
+							</tbody>
+						</table>
+					</article>
+				{% else %} <!-- If no daily totals are found -->							
+					<article class="box post post-excerpt">
+						<div class="box alert-info" style="font-size: 1.3em; border: 1px solid; padding: 16px; margin-bottom: 20px; text-align: center;">
+							No daily totals found. <!-- Message indicating no data -->
+						</div>
+					</article>
+					<p></p>
+				{% endif %}
 
-		<!-- Scripts -->
-			<script src="{{ url_for('static', filename='js/jquery.min.js') }}"></script>
-			<script src="{{ url_for('static', filename='js/browser.min.js') }}"></script>
-			<script src="{{ url_for('static', filename='js/breakpoints.min.js') }}"></script>
-			<script src="{{ url_for('static', filename='js/util.js') }}"></script>
-			<script src="{{ url_for('static', filename='js/main.js') }}"></script>
+				<!-- -- Pagination Section ------------------- -->
+				{% if dailysummary_pagination.pages > 1 %} <!-- Check if pagination is needed -->
+					<div class="pagination">
+						<!-- Previous Page Button -->
+						{% if dailysummary_pagination.has_prev %}
+							<a href="{{ url_for('dailysummary_paginated', page_num=dailysummary_pagination.prev_num) }}"
+							   class="button previous">Previous Page</a>
+						{% else %}
+							<span class="button previous disabled" aria-disabled="true">Previous Page</span>
+						{% endif %}
+						
+						<!-- Page Numbers -->
+						<div class="pages">
+							{% for page in dailysummary_pagination.iter_pages(left_edge=1, right_edge=1, left_current=2, right_current=2) %}
+								{% if page %}
+									<a href="{{ url_for('dailysummary_paginated', page_num=page) }}"
+									   class="{% if page == dailysummary_pagination.page %}active{% endif %}">{{ page }}</a>
+								{% else %}
+									<span>…</span> <!-- Ellipsis for skipped pages -->
+								{% endif %}
+							{% endfor %}
+						</div>
+						
+						<!-- Next Page Button -->
+						{% if dailysummary_pagination.has_next %}
+							<a href="{{ url_for('dailysummary_paginated', page_num=dailysummary_pagination.next_num) }}"
+							   class="button next">Next Page</a>
+						{% else %}
+							<span class="button next disabled" aria-disabled="true">Next Page</span>
+						{% endif %}
+					</div>
+				{% endif %}
+			</div>
+		</div>
+		<!-- == Sidebar Inclusion ============================================ -->
+		{% include '_sidebar.html' %} <!-- Include the sidebar template -->
+
+		<!-- == Scripts ============================================ -->
+		<script src="{{ url_for('static', filename='js/jquery.min.js') }}"></script>
+		<script src="{{ url_for('static', filename='js/browser.min.js') }}"></script>
+		<script src="{{ url_for('static', filename='js/breakpoints.min.js') }}"></script>
+		<script src="{{ url_for('static', filename='js/util.js') }}"></script>
+		<script src="{{ url_for('static', filename='js/main.js') }}"></script>
 	</body>
 </html>

--- a/templates/dailysummary.html
+++ b/templates/dailysummary.html
@@ -43,6 +43,7 @@
 									<th>Distance</th>
 									<th>Duration</th>
 									<th>Split</th>
+									<th>Total IsoReps</th>
 									<th>Actions</th>
 								</tr>
 							</thead>
@@ -56,6 +57,9 @@
 									</td>
 									<td>
 										{{ item_data.split | format_split_short }} <!-- Average split for the day -->
+									</td>
+									<td>
+										{{ '{:,.0f}'.format(item_data.isoreps) if item_data.isoreps is not none else '0' }}
 									</td>
 									<td>
 										<!-- Link to view detailed workouts for this specific date -->

--- a/templates/details.html
+++ b/templates/details.html
@@ -1,226 +1,231 @@
-<!-- templates/details.html -->
+<!-- ======================================================== -->
+<!-- = details.html - Template for displaying workout details -->
+<!-- ======================================================== -->
 <!DOCTYPE HTML>
 <html>
 	<head>
-		<title>RowErg Diary - Workout Details</title> <!-- More specific title -->
+		<title>RowErg Diary - Workout Details</title> <!-- Page Title -->
 		<meta charset="utf-8" />
 		<meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no" />
-		<link rel="icon" href="{{ url_for('static', filename='favicon.ico') }}">
-		<link rel="stylesheet" href="{{ url_for('static', filename='css/main.css') }}" />
-		<link rel="stylesheet" href="{{ url_for('static', filename='css/mystyles.css') }}" />
+		<link rel="icon" href="{{ url_for('static', filename='favicon.ico') }}"> <!-- Favicon Link -->
+		<link rel="stylesheet" href="{{ url_for('static', filename='css/main.css') }}" /> <!-- Main Stylesheet -->
+		<link rel="stylesheet" href="{{ url_for('static', filename='css/mystyles.css') }}" /> <!-- Custom Stylesheet -->
 	</head>
 	<body class="is-preload">
 
-		<!-- Content -->
-			<div id="content" class="custom-fullwidth">
-				<div class="inner">
-					<!-- flash messages -->
-						{% with messages = get_flashed_messages(with_categories=true) %}
-							{% if messages %}
-								<article class="box post post-excerpt">
-								{% for category, message in messages %}
-									<div class="box alert-{{ category }}" style="font-size: 1.3em; border: 1px solid; padding: 16px; margin-bottom: 20px; text-align: center;">
-										{{ message }}
-									</div>
-								{% endfor %}
-								</article>
-							{% endif %}
-						{% endwith %}
+		<!-- == Main Content Area ============================================ -->
+		<div id="content" class="custom-fullwidth">
+			<div class="inner">
+				<!-- -- Flash Messages Section ------------------- -->
+				{% with messages = get_flashed_messages(with_categories=true) %}
+					{% if messages %}
+						<article class="box post post-excerpt">
+						{% for category, message in messages %}
+							<div class="box alert-{{ category }}" style="font-size: 1.3em; border: 1px solid; padding: 16px; margin-bottom: 20px; text-align: center;">
+								{{ message }} <!-- Display flash message -->
+							</div>
+						{% endfor %}
+						</article>
+					{% endif %}
+				{% endwith %}
 					
-                    <div class="workout-details-main">
-                        <!-- Workout Title -->
-                        <div class="workout-header">
-                            <h1>{{ workout.workout_name | default('Unnamed Workout') }}</h1>
-                            <p class="workout-date">
-                                {{ workout.workout_date.strftime('%A, %B %d, %Y') if workout.workout_date else 'Date: N/A' }}
-                            </p>
-                        </div>
+				<div class="workout-details-main">
+					<!-- -- Workout Header Section ------------------- -->
+					<div class="workout-header">
+						<h1>{{ workout.workout_name | default('Unnamed Workout') }}</h1> <!-- Workout Name -->
+						<p class="workout-date">
+							{{ workout.workout_date.strftime('%A, %B %d, %Y') if workout.workout_date else 'Date: N/A' }} <!-- Workout Date -->
+						</p>
+					</div>
 
-                        <!-- General Information Card -->
-                        <div class="card info-card">
-                            <h2>General Information</h2>
-                            <div class="info-grid">
-                                <div><span>ID (DB):</span> {{ workout.workout_id }}</div>
-                                <div><span>Cardio Log ID:</span> {{ workout.cardio_log_id }}</div>
-                                <div><span>Equipment:</span> {{ workout.equipment_type_ref.name | default('N/A') }}</div>
-                                <div><span>Target:</span> {{ workout.target_description | default('N/A') }}</div>
-                                
-                                <div><span>Total Distance:</span> {{ '{:,.0f}'.format(workout.total_distance_meters) if workout.total_distance_meters is not none else 'N/A' }} m</div>
-                                <div><span>Total Duration:</span> {{ workout.duration_seconds | format_total_seconds_human_readable }}</div>
-                                <div><span>Average Split (/500m):</span> {{ workout.average_split_seconds_500m | format_split_ms }}</div>
-                            </div>
-                        </div>
+					<!-- -- General Information Card ------------------- -->
+					<div class="card info-card">
+						<h2>General Information</h2>
+						<div class="info-grid">
+							<div><span>ID (DB):</span> {{ workout.workout_id }}</div> <!-- Database ID -->
+							<div><span>Cardio Log ID:</span> {{ workout.cardio_log_id }}</div> <!-- External Log ID -->
+							<div><span>Equipment:</span> {{ workout.equipment_type_ref.name | default('N/A') }}</div> <!-- Equipment Used -->
+							<div><span>Target:</span> {{ workout.target_description | default('N/A') }}</div> <!-- Target Description -->
+							
+							<div><span>Total Distance:</span> {{ '{:,.0f}'.format(workout.total_distance_meters) if workout.total_distance_meters is not none else 'N/A' }} m</div> <!-- Total Distance -->
+							<div><span>Total Duration:</span> {{ workout.duration_seconds | format_total_seconds_human_readable }}</div> <!-- Total Duration -->
+							<div><span>Average Split (/500m):</span> {{ workout.average_split_seconds_500m | format_split_ms }}</div> <!-- Average Split -->
+						</div>
+					</div>
 
-                        <!-- Metric Descriptors Used in this Workout -->
-                        {% if workout_metric_descriptors %} {# Changed from workout.metric_descriptors #}
-                        <div class="card">
-                            <h2>Metric Descriptors Used</h2>
-                            <table class="styled-table">
-                                <thead>
-                                    <tr>
-                                        <!-- Removed JSON Index as it's not relevant for global descriptors in this context -->
-                                        <th>Name</th>
-                                        <th>Unit</th>
-                                    </tr>
-                                </thead>
-                                <tbody>
-                                    {# Iterate over workout_metric_descriptors passed from the view #}
-                                    {% for desc in workout_metric_descriptors %}
-                                    <tr>
-                                        <td>{{ desc.metric_name }}</td>
-                                        <td>{{ desc.unit_of_measure | default('N/A') }}</td>
-                                    </tr>
-                                    {% endfor %}
-                                </tbody>
-                            </table>
-                        </div>
-                        {% endif %}
+					<!-- -- Metric Descriptors Used Section ------------------- -->
+					{% if workout_metric_descriptors %} <!-- Check if metric descriptors are available -->
+					<div class="card">
+						<h2>Metric Descriptors Used</h2>
+						<table class="styled-table">
+							<thead>
+								<tr>
+									<th>Name</th>
+									<th>Unit</th>
+								</tr>
+							</thead>
+							<tbody>
+								{% for desc in workout_metric_descriptors %} <!-- Loop through each descriptor -->
+								<tr>
+									<td>{{ desc.metric_name }}</td> <!-- Metric Name -->
+									<td>{{ desc.unit_of_measure | default('N/A') }}</td> <!-- Unit of Measure -->
+								</tr>
+								{% endfor %}
+							</tbody>
+						</table>
+					</div>
+					{% endif %}
 
-                        <!-- Workout Samples -->
-                        {% if first_10_workout_samples or last_10_workout_samples %}
-                        <div class="card">
-                            <h2>Workout Samples
-                                <small>
-                                    {% if total_workout_samples == 0 %} (No samples recorded)
-                                    {% elif total_workout_samples <= 10 %} (Showing all {{ total_workout_samples }})
-                                    {% elif total_workout_samples <= 20 %} (Showing all {{ total_workout_samples }})
-                                    {% else %} (First 10 & Last 10 of {{ total_workout_samples }})
-                                    {% endif %}
-                                </small>
-                            </h2>
-                            {% if total_workout_samples > 0 %}
-                            <table class="styled-table">
-                                <thead>
-                                    <tr>
-                                        <th>Time Offset (s)</th>
-                                        <th>Metric Name</th> {# From sample.metric_descriptor_ref #}
-                                        <th>Value</th>
-                                        <th>Unit</th> {# From sample.metric_descriptor_ref #}
-                                    </tr>
-                                </thead>
-                                <tbody>
-                                    {% for sample in first_10_workout_samples %}
-                                    <tr>
-                                        <td>{{ sample.time_offset_seconds }}</td>
-                                        <td>{{ sample.metric_descriptor_ref.metric_name | default('N/A') }}</td>
-                                        <td>{{ "%.2f"|format(sample.value) if sample.value is not none else 'N/A' }}</td>
-                                        <td>{{ sample.metric_descriptor_ref.unit_of_measure | default('') }}</td>
-                                    </tr>
-                                    {% endfor %}
-                                    {% if workout_samples_ellipsis_needed %}
-                                    <tr>
-                                        <td colspan="4" class="ellipsis">... {{ total_workout_samples - 20 }} more samples ...</td>
-                                    </tr>
-                                    {% endif %}
-                                    {% if workout_samples_ellipsis_needed or (total_workout_samples > 10 and total_workout_samples <= 20) %}
-                                        {% for sample in last_10_workout_samples %}
-                                        <tr>
-                                            <td>{{ sample.time_offset_seconds }}</td>
-                                            <td>{{ sample.metric_descriptor_ref.metric_name | default('N/A') }}</td>
-                                            <td>{{ "%.2f"|format(sample.value) if sample.value is not none else 'N/A' }}</td>
-                                            <td>{{ sample.metric_descriptor_ref.unit_of_measure | default('') }}</td>
-                                        </tr>
-                                        {% endfor %}
-                                    {% endif %}
-                                </tbody>
-                            </table>
-                            {% else %}
-                            <p class="no-data">No workout samples available for this workout.</p>
-                            {% endif %}
-                        </div>
-                        {% endif %}
+					<!-- -- Workout Samples Section ------------------- -->
+					{% if first_10_workout_samples or last_10_workout_samples %} <!-- Check if workout samples are available -->
+					<div class="card">
+						<h2>Workout Samples
+							<small> <!-- Sub-heading for sample count -->
+								{% if total_workout_samples == 0 %} (No samples recorded)
+								{% elif total_workout_samples <= 10 %} (Showing all {{ total_workout_samples }})
+								{% elif total_workout_samples <= 20 %} (Showing all {{ total_workout_samples }})
+								{% else %} (First 10 & Last 10 of {{ total_workout_samples }})
+								{% endif %}
+							</small>
+						</h2>
+						{% if total_workout_samples > 0 %}
+						<table class="styled-table">
+							<thead>
+								<tr>
+									<th>Time Offset (s)</th>
+									<th>Metric Name</th>
+									<th>Value</th>
+									<th>Unit</th>
+								</tr>
+							</thead>
+							<tbody>
+								<!-- ---- First 10 Workout Samples ---- -->
+								{% for sample in first_10_workout_samples %}
+								<tr>
+									<td>{{ sample.time_offset_seconds }}</td> <!-- Time Offset -->
+									<td>{{ sample.metric_descriptor_ref.metric_name | default('N/A') }}</td> <!-- Metric Name from related descriptor -->
+									<td>{{ "%.2f"|format(sample.value) if sample.value is not none else 'N/A' }}</td> <!-- Sample Value (formatted) -->
+									<td>{{ sample.metric_descriptor_ref.unit_of_measure | default('') }}</td> <!-- Unit from related descriptor -->
+								</tr>
+								{% endfor %}
+								<!-- ---- Ellipsis if more than 20 samples ---- -->
+								{% if workout_samples_ellipsis_needed %}
+								<tr>
+									<td colspan="4" class="ellipsis">... {{ total_workout_samples - 20 }} more samples ...</td> <!-- Ellipsis row -->
+								</tr>
+								{% endif %}
+								<!-- ---- Last 10 Workout Samples (if applicable) ---- -->
+								{% if workout_samples_ellipsis_needed or (total_workout_samples > 10 and total_workout_samples <= 20) %}
+									{% for sample in last_10_workout_samples %}
+									<tr>
+										<td>{{ sample.time_offset_seconds }}</td>
+										<td>{{ sample.metric_descriptor_ref.metric_name | default('N/A') }}</td>
+										<td>{{ "%.2f"|format(sample.value) if sample.value is not none else 'N/A' }}</td>
+										<td>{{ sample.metric_descriptor_ref.unit_of_measure | default('') }}</td>
+									</tr>
+									{% endfor %}
+								{% endif %}
+							</tbody>
+						</table>
+						{% else %}
+						<p class="no-data">No workout samples available for this workout.</p> <!-- Message if no samples -->
+						{% endif %}
+					</div>
+					{% endif %}
 
-                        <!-- Heart Rate Samples (structure unchanged) -->
-                        {% if first_10_hr_samples or last_10_hr_samples %}
-                        <!-- ... (HR samples table remains the same) ... -->
-                        <div class="card">
-                            <h2>Heart Rate Samples
-                                <small>
-                                    {% if total_hr_samples == 0 %} (No HR samples recorded)
-                                    {% elif total_hr_samples <= 10 %} (Showing all {{ total_hr_samples }})
-                                    {% elif total_hr_samples <= 20 %} (Showing all {{ total_hr_samples }})
-                                    {% else %} (First 10 & Last 10 of {{ total_hr_samples }})
-                                    {% endif %}
-                                </small>
-                            </h2>
-                            {% if total_hr_samples > 0 %}
-                            <table class="styled-table">
-                                <thead>
-                                    <tr>
-                                        <th>Time Offset (s)</th>
-                                        <th>Heart Rate (bpm)</th>
-                                    </tr>
-                                </thead>
-                                <tbody>
-                                    {% for sample in first_10_hr_samples %}
-                                    <tr>
-                                        <td>{{ sample.time_offset_seconds }}</td>
-                                        <td>{{ sample.heart_rate_bpm if sample.heart_rate_bpm is not none else 'N/A' }}</td>
-                                    </tr>
-                                    {% endfor %}
-                                    {% if hr_samples_ellipsis_needed %}
-                                    <tr>
-                                        <td colspan="2" class="ellipsis">... {{ total_hr_samples - 20 }} more samples ...</td>
-                                    </tr>
-                                    {% endif %}
-                                    {% if hr_samples_ellipsis_needed or (total_hr_samples > 10 and total_hr_samples <= 20) %}
-                                        {% for sample in last_10_hr_samples %}
-                                        <tr>
-                                            <td>{{ sample.time_offset_seconds }}</td>
-                                            <td>{{ sample.heart_rate_bpm if sample.heart_rate_bpm is not none else 'N/A' }}</td>
-                                        </tr>
-                                        {% endfor %}
-                                    {% endif %}
-                                </tbody>
-                            </table>
-                            {% else %}
-                            <p class="no-data">No heart rate samples available for this workout.</p>
-                            {% endif %}
-                        </div>
-                        {% endif %}
+					<!-- -- Heart Rate Samples Section ------------------- -->
+					{% if first_10_hr_samples or last_10_hr_samples %} <!-- Check if HR samples are available -->
+					<div class="card">
+						<h2>Heart Rate Samples
+							<small> <!-- Sub-heading for HR sample count -->
+								{% if total_hr_samples == 0 %} (No HR samples recorded)
+								{% elif total_hr_samples <= 10 %} (Showing all {{ total_hr_samples }})
+								{% elif total_hr_samples <= 20 %} (Showing all {{ total_hr_samples }})
+								{% else %} (First 10 & Last 10 of {{ total_hr_samples }})
+								{% endif %}
+							</small>
+						</h2>
+						{% if total_hr_samples > 0 %}
+						<table class="styled-table">
+							<thead>
+								<tr>
+									<th>Time Offset (s)</th>
+									<th>Heart Rate (bpm)</th>
+								</tr>
+							</thead>
+							<tbody>
+								<!-- ---- First 10 HR Samples ---- -->
+								{% for sample in first_10_hr_samples %}
+								<tr>
+									<td>{{ sample.time_offset_seconds }}</td> <!-- Time Offset -->
+									<td>{{ sample.heart_rate_bpm if sample.heart_rate_bpm is not none else 'N/A' }}</td> <!-- Heart Rate Value -->
+								</tr>
+								{% endfor %}
+								<!-- ---- Ellipsis if more than 20 HR samples ---- -->
+								{% if hr_samples_ellipsis_needed %}
+								<tr>
+									<td colspan="2" class="ellipsis">... {{ total_hr_samples - 20 }} more samples ...</td> <!-- Ellipsis row -->
+								</tr>
+								{% endif %}
+								<!-- ---- Last 10 HR Samples (if applicable) ---- -->
+								{% if hr_samples_ellipsis_needed or (total_hr_samples > 10 and total_hr_samples <= 20) %}
+									{% for sample in last_10_hr_samples %}
+									<tr>
+										<td>{{ sample.time_offset_seconds }}</td>
+										<td>{{ sample.heart_rate_bpm if sample.heart_rate_bpm is not none else 'N/A' }}</td>
+									</tr>
+									{% endfor %}
+								{% endif %}
+							</tbody>
+						</table>
+						{% else %}
+						<p class="no-data">No heart rate samples available for this workout.</p> <!-- Message if no HR samples -->
+						{% endif %}
+					</div>
+					{% endif %}
 
-                        <!-- Heart Rate Zones (structure unchanged) -->
-                        {% if workout.workout_hr_zones and workout.workout_hr_zones|length > 0 %}
-                        <!-- ... (HR zones table remains the same) ... -->
-                        <div class="card">
-                            <h2>Heart Rate Zones</h2>
-                            <table class="styled-table">
-                                <thead>
-                                    <tr>
-                                        <th>Zone Name</th>
-                                        <th>Color</th>
-                                        <th>Lower BPM</th>
-                                        <th>Upper BPM</th>
-                                        <th>Seconds in Zone</th>
-                                    </tr>
-                                </thead>
-                                <tbody>
-                                    {% for zone in workout.workout_hr_zones | sort(attribute='lower_bound_bpm') %}
-                                    <tr>
-                                        <td>{{ zone.zone_name }}</td>
-                                        <td>
-                                            <span class="zone-color" style="background:{{ zone.color_hex | default('transparent') }};"></span>
-                                            {{ zone.color_hex | default('N/A') }}
-                                        </td>
-                                        <td>{{ "%.1f"|format(zone.lower_bound_bpm) if zone.lower_bound_bpm is not none else 'N/A' }}</td>
-                                        <td>{{ "%.1f"|format(zone.upper_bound_bpm) if zone.upper_bound_bpm is not none else 'N/A' }}</td>
-                                        <td>{{ "%.1f"|format(zone.seconds_in_zone) if zone.seconds_in_zone is not none else 'N/A' }}</td>
-                                    </tr>
-                                    {% endfor %}
-                                </tbody>
-                            </table>
-                        </div>
-                        {% endif %}
+					<!-- -- Heart Rate Zones Section ------------------- -->
+					{% if workout.workout_hr_zones and workout.workout_hr_zones|length > 0 %} <!-- Check if HR zones are available -->
+					<div class="card">
+						<h2>Heart Rate Zones</h2>
+						<table class="styled-table">
+							<thead>
+								<tr>
+									<th>Zone Name</th>
+									<th>Color</th>
+									<th>Lower BPM</th>
+									<th>Upper BPM</th>
+									<th>Seconds in Zone</th>
+								</tr>
+							</thead>
+							<tbody>
+								{% for zone in workout.workout_hr_zones | sort(attribute='lower_bound_bpm') %} <!-- Loop through each zone, sorted -->
+								<tr>
+									<td>{{ zone.zone_name }}</td> <!-- Zone Name -->
+									<td>
+										<span class="zone-color" style="background:{{ zone.color_hex | default('transparent') }};"></span> <!-- Color indicator -->
+										{{ zone.color_hex | default('N/A') }} <!-- Color Hex Code -->
+									</td>
+									<td>{{ "%.1f"|format(zone.lower_bound_bpm) if zone.lower_bound_bpm is not none else 'N/A' }}</td> <!-- Lower BPM -->
+									<td>{{ "%.1f"|format(zone.upper_bound_bpm) if zone.upper_bound_bpm is not none else 'N/A' }}</td> <!-- Upper BPM -->
+									<td>{{ "%.1f"|format(zone.seconds_in_zone) if zone.seconds_in_zone is not none else 'N/A' }}</td> <!-- Time in Zone -->
+								</tr>
+								{% endfor %}
+							</tbody>
+						</table>
+					</div>
+					{% endif %}
 
-                        <!-- Back Link -->
-                        <div class="back-link-container">
-                            <a href="javascript:window.history.back();" class="back-link">
-                                ← Back
-                            </a>
-                        </div>
-                    </div>
+					<!-- -- Back Link Section ------------------- -->
+					<div class="back-link-container">
+						<a href="javascript:window.history.back();" class="back-link">
+							← Back <!-- Link to go back to the previous page -->
+						</a>
+					</div>
+				</div>
 
-                    <style>
+				<!-- -- Inline Styles Section (Consider moving to CSS file) ------------------- -->
+				<style>
                     /* Inline styles remain the same for now */
                     .workout-details-main { max-width: 900px; margin: 0 auto 40px auto; padding: 20px 10px; }
                     .workout-header { text-align: center; margin-bottom: 24px; }
@@ -244,17 +249,17 @@
                         .card { padding: 14px 6px 10px 6px; }
                         .info-card .info-grid { grid-template-columns: 1fr; }
                     }
-                    </style>
-				</div>
+                </style>
 			</div>
-		<!-- Sidebar -->
-			{% include '_sidebar.html' %}
+		</div>
+		<!-- == Sidebar Inclusion ============================================ -->
+		{% include '_sidebar.html' %} <!-- Include the sidebar template -->
 
-		<!-- Scripts -->
-			<script src="{{ url_for('static', filename='js/jquery.min.js') }}"></script>
-			<script src="{{ url_for('static', filename='js/browser.min.js') }}"></script>
-			<script src="{{ url_for('static', filename='js/breakpoints.min.js') }}"></script>
-			<script src="{{ url_for('static', filename='js/util.js') }}"></script>
-			<script src="{{ url_for('static', filename='js/main.js') }}"></script>
+		<!-- == Scripts ============================================ -->
+		<script src="{{ url_for('static', filename='js/jquery.min.js') }}"></script>
+		<script src="{{ url_for('static', filename='js/browser.min.js') }}"></script>
+		<script src="{{ url_for('static', filename='js/breakpoints.min.js') }}"></script>
+		<script src="{{ url_for('static', filename='js/util.js') }}"></script>
+		<script src="{{ url_for('static', filename='js/main.js') }}"></script>
 	</body>
 </html>

--- a/templates/index.html
+++ b/templates/index.html
@@ -32,27 +32,50 @@
 							<div class="flex-container">
 								<div class="flex-box">
 									<h3>Manual Workout Input</h3>
-									<form id="workoutInputForm" style="height:100%;display:flex;flex-direction:column;">
-										<div style="flex:0 0 auto;">
-											<label for="workoutDate">Date:</label>
-											<input type="date" id="workoutDate" name="workoutDate" required>
-										</div>
-										<div style="flex:0 0 auto;">
-											<label for="workoutTime">Time (HH:MM:SS.ms):</label>
-											<input type="text" id="workoutTime" name="workoutTime" placeholder="1:46:45.2 or 65:45.2" required pattern="^([0-9]+:)?([0-9]+:){1}([0-5]?[0-9])(\.[0-9]+)?$">
-										</div>
-										<div>
-											<label for="workoutDistance">Distance (Meters):</label>
-											<input type="number" id="workoutDistance" name="workoutDistance" placeholder="e.g., 2000" required>
-										</div>
-										<div>
-											<label for="workoutLevel">Level:</label>
-											<input type="text" id="workoutLevel" name="workoutLevel" placeholder="1-10">
-										</div>
-										<div>
-											<label for="calculatedPace">Pace:</label>
-											<input type="text" id="calculatedPace" name="calculatedPace" placeholder="--:--.--" readonly>
-										</div>
+									<form id="workoutInputForm">
+										<!-- Line 1: Workout Type -->
+                                        <div class="form-row-split">
+											<div class="form-field-group">
+												<label for="workoutName">Name:</label>
+												<input type="text" id="workoutName" name="workoutName" placeholder="e.g., Morning Row">
+											</div>
+											<div class="form-field-group">
+												<label for="workoutDate">Date:</label>
+												<input type="date" id="workoutDate" name="workoutDate" required>
+											</div>
+                                        </div>
+										
+                                        <!-- Line 3: Time and Distance -->
+                                        <div class="form-row-split">
+                                            <div class="form-field-group">
+                                                <label for="workoutTime">Time (HH:MM:SS.ms):</label>
+                                                <input type="text" id="workoutTime" name="workoutTime" placeholder="1:46:45.2 or 65:45.2" required pattern="^([0-9]+:)?([0-9]+:){1}([0-5]?[0-9])(\.[0-9]+)?$">
+                                            </div>
+                                            <div class="form-field-group">
+                                                <label for="workoutDistance">Distance (Meters):</label>
+                                                <input type="number" id="workoutDistance" name="workoutDistance" placeholder="e.g., 2000" required>
+                                            </div>
+                                        </div>
+
+                                        <!-- Line 4: Level and Pace -->
+                                        <div class="form-row-split">
+                                            <div class="form-field-group">
+                                                <label for="workoutLevel">Level:</label>
+                                                <input type="text" id="workoutLevel" name="workoutLevel" placeholder="1-10">
+                                            </div>
+                                            <div class="form-field-group">
+                                                <label for="calculatedPace">Pace:</label>
+                                                <input type="text" id="calculatedPace" name="calculatedPace" placeholder="--:--.--" readonly>
+                                            </div>
+                                        </div>
+
+                                        <!-- Line 5: Notes -->
+                                        <div>
+                                            <label for="workoutNotes">Notes:</label>
+                                            <textarea id="workoutNotes" name="workoutNotes" placeholder="e.g., Feeling strong today!"></textarea>
+                                        </div>
+                                        
+                                        <!-- Line 6: Button -->
 										<button type="submit" id="workoutSubmitBtn" class="button">Add Workout</button>
 									</form>
 								</div>
@@ -60,8 +83,13 @@
 									<h3>Mywelness Json Import</h3>
 									<form id="jsonInputForm" method="POST" action="{{ url_for('submit_json_workout') }}">
 										<div>
-											<textarea id="jsonData" name="jsonData" placeholder='{"key": "value"}' required style="padding: 6px 8px; border: 1px solid #b3c6e7; border-radius: 4px; background: #f8fbff; font-size: 1em; color: #222; transition: border 0.2s; min-height: 80px; resize: vertical;"></textarea>
+                                            <label for="jsonData">Json:</label>
+											<textarea id="jsonData" class="text_data" name="jsonData" placeholder='{"key": "value"}' required></textarea>
 										</div>
+                                        <div>
+                                            <label for="jsonNotes">Notes:</label>
+                                            <textarea id="jsonNotes" name="jsonNotes" placeholder="Any specific notes for this imported workout?"></textarea>
+                                        </div>
 										<div>
 											<button type="submit" id="jsonSubmitBtn" class="button">Submit JSON</button>
 										</div>

--- a/templates/index.html
+++ b/templates/index.html
@@ -32,7 +32,7 @@
 							<div class="flex-container">
 								<div class="flex-box">
 									<h3>Manual Workout Input</h3>
-									<form id="workoutInputForm">
+									<form id="workoutInputForm" method="POST" action="{{ url_for('submit_manual_workout') }}">
 										<!-- Line 1: Workout Type -->
                                         <div class="form-row-split">
 											<div class="form-field-group">

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,149 +1,154 @@
-<!-- templates/index.html -->
+<!-- ======================================================== -->
+<!-- = index.html - Main landing page for RowErg Diary      -->
+<!-- ======================================================== -->
 <!DOCTYPE HTML>
 <html>
 	<head>
-		<title>RowErg Diary</title>
+		<title>RowErg Diary</title> <!-- Page Title -->
 		<meta charset="utf-8" />
 		<meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no" />
-		<link rel="icon" href="{{ url_for('static', filename='favicon.ico') }}">
-		<link rel="stylesheet" href="{{ url_for('static', filename='css/main.css') }}" />
-		<link rel="stylesheet" href="{{ url_for('static', filename='css/mystyles.css') }}" />
+		<link rel="icon" href="{{ url_for('static', filename='favicon.ico') }}"> <!-- Favicon Link -->
+		<link rel="stylesheet" href="{{ url_for('static', filename='css/main.css') }}" /> <!-- Main Stylesheet -->
+		<link rel="stylesheet" href="{{ url_for('static', filename='css/mystyles.css') }}" /> <!-- Custom Stylesheet -->
 	</head>
 	<body class="is-preload">
 
-		<!-- Content -->
-			<div id="content" class="custom-calendar">
-				<div class="inner">
-					<!-- flash messages -->
-						{% with messages = get_flashed_messages(with_categories=true) %}
-							{% if messages %}
-								<article class="box post post-excerpt">
-								{% for category, message in messages %}
-									<div class="box alert-{{ category }}" style="font-size: 1.3em; border: 1px solid; padding: 16px; margin-bottom: 20px; text-align: center;">
-										{{ message }}
-									</div>
-								{% endfor %}
-								</article>
-							{% endif %}
-						{% endwith %}
-
-					<!-- Widgets (structure unchanged) -->
+		<!-- == Main Content Area ============================================ -->
+		<div id="content" class="custom-calendar">
+			<div class="inner">
+				<!-- -- Flash Messages Section ------------------- -->
+				{% with messages = get_flashed_messages(with_categories=true) %}
+					{% if messages %}
 						<article class="box post post-excerpt">
-							<div class="flex-container">
-								<div class="flex-box">
-									<h3>Manual Workout Input</h3>
-									<form id="workoutInputForm" method="POST" action="{{ url_for('submit_manual_workout') }}">
-										<!-- Line 1: Workout Type -->
-                                        <div class="form-row-split">
-											<div class="form-field-group">
-												<label for="workoutName">Name:</label>
-												<input type="text" id="workoutName" name="workoutName" placeholder="e.g., Morning Row">
-											</div>
-											<div class="form-field-group">
-												<label for="workoutDate">Date:</label>
-												<input type="date" id="workoutDate" name="workoutDate" required>
-											</div>
-                                        </div>
-										
-                                        <!-- Line 3: Time and Distance -->
-                                        <div class="form-row-split">
-                                            <div class="form-field-group">
-                                                <label for="workoutTime">Time (HH:MM:SS.ms):</label>
-                                                <input type="text" id="workoutTime" name="workoutTime" placeholder="1:46:45.2 or 65:45.2" required pattern="^([0-9]+:)?([0-9]+:){1}([0-5]?[0-9])(\.[0-9]+)?$">
-                                            </div>
-                                            <div class="form-field-group">
-                                                <label for="workoutDistance">Distance (Meters):</label>
-                                                <input type="number" id="workoutDistance" name="workoutDistance" placeholder="e.g., 2000" required>
-                                            </div>
-                                        </div>
+						{% for category, message in messages %}
+							<div class="box alert-{{ category }}" style="font-size: 1.3em; border: 1px solid; padding: 16px; margin-bottom: 20px; text-align: center;">
+								{{ message }} <!-- Display flash message -->
+							</div>
+						{% endfor %}
+						</article>
+					{% endif %}
+				{% endwith %}
 
-                                        <!-- Line 4: Level and Pace -->
-                                        <div class="form-row-split">
-                                            <div class="form-field-group">
-                                                <label for="workoutLevel">Level:</label>
-                                                <input type="text" id="workoutLevel" name="workoutLevel" placeholder="1-10">
-                                            </div>
-                                            <div class="form-field-group">
-                                                <label for="calculatedPace">Pace:</label>
-                                                <input type="text" id="calculatedPace" name="calculatedPace" placeholder="--:--.--" readonly>
-                                            </div>
-                                        </div>
+				<!-- -- Input Forms Section (Widgets) ------------------- -->
+				<article class="box post post-excerpt">
+					<div class="flex-container">
+						<!-- --- Manual Workout Input Form ------------------- -->
+						<div class="flex-box">
+							<h3>Manual Workout Input</h3>
+							<form id="workoutInputForm" method="POST" action="{{ url_for('submit_manual_workout') }}">
+								<!-- ---- Workout Name and Date ------------------- -->
+								<div class="form-row-split">
+									<div class="form-field-group">
+										<label for="workoutName">Name:</label>
+										<input type="text" id="workoutName" name="workoutName" placeholder="e.g., Morning Row">
+									</div>
+									<div class="form-field-group">
+										<label for="workoutDate">Date:</label>
+										<input type="date" id="workoutDate" name="workoutDate" required>
+									</div>
+								</div>
+								
+								<!-- ---- Workout Time and Distance ------------------- -->
+								<div class="form-row-split">
+									<div class="form-field-group">
+										<label for="workoutTime">Time (HH:MM:SS.ms):</label>
+										<input type="text" id="workoutTime" name="workoutTime" placeholder="1:46:45.2 or 65:45.2" required pattern="^([0-9]+:)?([0-9]+:){1}([0-5]?[0-9])(\.[0-9]+)?$">
+									</div>
+									<div class="form-field-group">
+										<label for="workoutDistance">Distance (Meters):</label>
+										<input type="number" id="workoutDistance" name="workoutDistance" placeholder="e.g., 2000" required>
+									</div>
+								</div>
 
-                                        <!-- Line 5: Notes -->
-                                        <div>
-                                            <label for="workoutNotes">Notes:</label>
-                                            <textarea id="workoutNotes" name="workoutNotes" placeholder="e.g., Feeling strong today!"></textarea>
-                                        </div>
-                                        
-                                        <!-- Line 6: Button -->
-										<button type="submit" id="workoutSubmitBtn" class="button">Add Workout</button>
-									</form>
+								<!-- ---- Workout Level and Calculated Pace ------------------- -->
+								<div class="form-row-split">
+									<div class="form-field-group">
+										<label for="workoutLevel">Level:</label>
+										<input type="text" id="workoutLevel" name="workoutLevel" placeholder="1-10">
+									</div>
+									<div class="form-field-group">
+										<label for="calculatedPace">Pace:</label>
+										<input type="text" id="calculatedPace" name="calculatedPace" placeholder="--:--.--" readonly> <!-- Pace is auto-calculated by pace.js -->
+									</div>
 								</div>
-								<div class="flex-box">
-									<h3>Mywelness Json Import</h3>
-									<form id="jsonInputForm" method="POST" action="{{ url_for('submit_json_workout') }}">
-										<div>
-                                            <label for="jsonData">Json:</label>
-											<textarea id="jsonData" class="text_data" name="jsonData" placeholder='{"key": "value"}' required></textarea>
-										</div>
-                                        <div>
-                                            <label for="jsonNotes">Notes:</label>
-                                            <textarea id="jsonNotes" name="jsonNotes" placeholder="Any specific notes for this imported workout?"></textarea>
-                                        </div>
-										<div>
-											<button type="submit" id="jsonSubmitBtn" class="button">Submit JSON</button>
-										</div>
-									</form>
+
+								<!-- ---- Workout Notes ------------------- -->
+								<div>
+									<label for="workoutNotes">Notes:</label>
+									<textarea id="workoutNotes" name="workoutNotes" placeholder="e.g., Feeling strong today!"></textarea>
 								</div>
+								
+								<!-- ---- Submit Button ------------------- -->
+								<button type="submit" id="workoutSubmitBtn" class="button">Add Workout</button>
+							</form>
+						</div>
+						<!-- --- JSON Import Form ------------------- -->
+						<div class="flex-box">
+							<h3>Mywelness Json Import</h3>
+							<form id="jsonInputForm" method="POST" action="{{ url_for('submit_json_workout') }}">
+								<div>
+									<label for="jsonData">Json:</label>
+									<textarea id="jsonData" class="text_data" name="jsonData" placeholder='{"key": "value"}' required></textarea>
+								</div>
+								<div>
+									<label for="jsonNotes">Notes:</label>
+									<textarea id="jsonNotes" name="jsonNotes" placeholder="Any specific notes for this imported workout?"></textarea>
+								</div>
+								<div>
+									<button type="submit" id="jsonSubmitBtn" class="button">Submit JSON</button>
+								</div>
+							</form>
+						</div>
+					</div>
+				</article>
+						
+				<!-- -- Recent Workouts List Section ------------------- -->
+				{% if workouts_display_data %} <!-- Check if there are recent workouts to display -->
+					{% for item_data in workouts_display_data %} <!-- Loop through each recent workout -->
+						<hr class="extra_article"> <!-- Separator line -->
+						<article class="box post post-excerpt">
+							<header style="margin-bottom: 0px; padding-top: 0px;">
+								<h2 style="margin-bottom: 5px;"><a href="{{ url_for('details', workout_id=item_data.workout_obj.workout_id) }}">{{ item_data.name | default('Unnamed Workout') }}</a></h2> <!-- Workout Name (link to details) -->
+							</header>
+							<div class="info">
+								<!-- Workout Date (formatted) -->
+								<span class="date"><span class="month">{{ item_data.workout_obj.workout_date.strftime('%b') if item_data.workout_obj.workout_date else 'N/A' }}<span>{{ (item_data.workout_obj.workout_date.strftime('%B'))[3:] if item_data.workout_obj.workout_date else 'N/A' }}</span></span> <span class="day">{{ item_data.workout_obj.workout_date.strftime('%d') if item_data.workout_obj.workout_date else 'N/A' }}</span><span class="year">, {{ item_data.workout_obj.workout_date.strftime('%Y') if item_data.workout_obj.workout_date else 'N/A' }}</span></span>
+								<!-- Workout Stats -->
+								<ul class="stats">
+									<li><a href="#" class="icon distance">{{ '{:,.0f}'.format(item_data.workout_obj.total_distance_meters) if item_data.workout_obj.total_distance_meters is not none else 'N/A' }} m</a></li> <!-- Total Distance -->
+									<li><a href="#" class="icon time">{{ item_data.workout_obj.duration_seconds | format_total_seconds_human_readable }}</a></li> <!-- Duration -->
+									<li><a href="#" class="icon split">{{ item_data.workout_obj.average_split_seconds_500m | format_split_ms }}</a></li> <!-- Average Split -->
+									
+									<li><a href="{{ url_for('details', workout_id=item_data.workout_obj.workout_id) }}" class="icon details" style="color:green">Details</a></li> <!-- Link to Details Page -->
+									<li><a href="#" class="icon brands fa-facebook-f"></a></li> <!-- Placeholder Social Media Icon -->
+								</ul>
+							</div>
+							<!-- Placeholder for Workout Graph -->
+							<div id="workout-graph-placeholder-{{ loop.index }}" style="width:100%; height:250px; background:#f4f7fb; border:1px dashed #b3c6e7; display:flex; align-items:center; justify-content:center; margin: 0px 0;">
+								<span style="color:#6a8fd7; font-size:1.2em;">[ Graph for {{ item_data.workout_obj.workout_name | default('Workout') }} ]</span>
 							</div>
 						</article>
-						
-					<!-- Workouts -->
-						{% if workouts_display_data %}
-							{% for item_data in workouts_display_data %}
-								<hr class="extra_article">
-								<article class="box post post-excerpt">
-									<header style="margin-bottom: 0px; padding-top: 0px;">
-										<h2 style="margin-bottom: 5px;"><a href="{{ url_for('details', workout_id=item_data.workout_obj.workout_id) }}">{{ item_data.name | default('Unnamed Workout') }}</a></h2>
-									</header>
-									<div class="info">
-										<span class="date"><span class="month">{{ item_data.workout_obj.workout_date.strftime('%b') if item_data.workout_obj.workout_date else 'N/A' }}<span>{{ (item_data.workout_obj.workout_date.strftime('%B'))[3:] if item_data.workout_obj.workout_date else 'N/A' }}</span></span> <span class="day">{{ item_data.workout_obj.workout_date.strftime('%d') if item_data.workout_obj.workout_date else 'N/A' }}</span><span class="year">, {{ item_data.workout_obj.workout_date.strftime('%Y') if item_data.workout_obj.workout_date else 'N/A' }}</span></span>
-										<ul class="stats">
-                                            {# Assuming views/home.py now provides formatted strings in item_data.summary #}
-                                            {# If views/home.py provides raw numbers for workout_obj, use filters: #}
-											<li><a href="#" class="icon distance">{{ '{:,.0f}'.format(item_data.workout_obj.total_distance_meters) if item_data.workout_obj.total_distance_meters is not none else 'N/A' }} m</a></li>
-											<li><a href="#" class="icon time">{{ item_data.workout_obj.duration_seconds | format_total_seconds_human_readable }}</a></li>
-											<li><a href="#" class="icon split">{{ item_data.workout_obj.average_split_seconds_500m | format_split_ms }}</a></li>
-											
-                                            <li><a href="{{ url_for('details', workout_id=item_data.workout_obj.workout_id) }}" class="icon details" style="color:green">Details</a></li>
-											<li><a href="#" class="icon brands fa-facebook-f"></a></li> {# Placeholder icon #}
-										</ul>
-									</div>
-									<div id="workout-graph-placeholder-{{ loop.index }}" style="width:100%; height:250px; background:#f4f7fb; border:1px dashed #b3c6e7; display:flex; align-items:center; justify-content:center; margin: 0px 0;">
-										<span style="color:#6a8fd7; font-size:1.2em;">[ Graph for {{ item_data.workout_obj.workout_name | default('Workout') }} ]</span>
-									</div>
-								</article>
-							{% endfor %}
-					{% else %}								
-							<article class="box post post-excerpt">
-								<div class="box alert-info" style="font-size: 1.3em; border: 1px solid; padding: 16px; margin-bottom: 20px; text-align: center;">
-									No workouts found.
-								</div>
-							</article>
-						<p></p>
-					{% endif %}
+					{% endfor %}
+				{% else %} <!-- If no recent workouts are found -->							
+					<article class="box post post-excerpt">
+						<div class="box alert-info" style="font-size: 1.3em; border: 1px solid; padding: 16px; margin-bottom: 20px; text-align: center;">
+							No workouts found. <!-- Message indicating no workouts -->
+						</div>
+					</article>
+					<p></p>
+				{% endif %}
 					
-				</div>
 			</div>
-		<!-- Sidebar -->
-			{% include '_sidebar.html' %}
+		</div>
+		<!-- == Sidebar Inclusion ============================================ -->
+		{% include '_sidebar.html' %} <!-- Include the sidebar template -->
 
-		<!-- Scripts -->
-			<script src="{{ url_for('static', filename='js/jquery.min.js') }}"></script>
-			<script src="{{ url_for('static', filename='js/browser.min.js') }}"></script>
-			<script src="{{ url_for('static', filename='js/breakpoints.min.js') }}"></script>
-			<script src="{{ url_for('static', filename='js/util.js') }}"></script>
-			<script src="{{ url_for('static', filename='js/main.js') }}"></script>
-			<script src="{{ url_for('static', filename='js/pace.js') }}"></script>
+		<!-- == Scripts ============================================ -->
+		<script src="{{ url_for('static', filename='js/jquery.min.js') }}"></script>
+		<script src="{{ url_for('static', filename='js/browser.min.js') }}"></script>
+		<script src="{{ url_for('static', filename='js/breakpoints.min.js') }}"></script>
+		<script src="{{ url_for('static', filename='js/util.js') }}"></script>
+		<script src="{{ url_for('static', filename='js/main.js') }}"></script>
+		<script src="{{ url_for('static', filename='js/pace.js') }}"></script> <!-- Script for pace calculation -->
 	</body>
 </html>

--- a/templates/monthlysummary.html
+++ b/templates/monthlysummary.html
@@ -1,0 +1,125 @@
+<!-- ======================================================== -->
+<!-- = monthlysummary.html - Template for displaying monthly workout summaries -->
+<!-- ======================================================== -->
+<!DOCTYPE HTML>
+<html>
+	<head>
+		<title>{{ page_title | default('Monthly Workout Totals') }}</title>
+		<meta charset="utf-8" />
+		<meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no" />
+		<link rel="icon" href="{{ url_for('static', filename='favicon.ico') }}">
+		<link rel="stylesheet" href="{{ url_for('static', filename='css/main.css') }}" />
+		<link rel="stylesheet" href="{{ url_for('static', filename='css/mystyles.css') }}" />
+	</head>
+	<body class="is-preload">
+
+		<!-- == Main Content Area ============================================ -->
+		<div id="content" class="custom-fullwidth">
+			<div class="inner">
+				<!-- -- Page Header ------------------- -->
+				<h1 class="extra_h1">{{ page_title | default('Monthly Summary') }}</h1>
+				<hr class="extra_title_line">
+
+				<!-- -- Flash Messages Section ------------------- -->
+				{% with messages = get_flashed_messages(with_categories=true) %}
+					{% if messages %}
+						<article class="box post post-excerpt">
+						{% for category, message in messages %}
+							<div class="box alert-{{ category }}" style="font-size: 1.3em; border: 1px solid; padding: 16px; margin-bottom: 20px; text-align: center;">
+								{{ message }}
+							</div>
+						{% endfor %}
+						</article>
+					{% endif %}
+				{% endwith %}
+					
+				<!-- -- Monthly Totals Table Section ------------------- -->
+				{% if monthlysummary_display_data %}
+					<article class="box post post-excerpt">
+						<div class="table-wrapper">
+							<table>
+								<thead>
+									<tr>
+										<th>Month (YYYY-MM)</th>
+										<th>Distance</th>
+										<th>Duration</th>
+										<th>Avg. Split</th>
+										<th>Total IsoReps</th>
+										<th>Actions</th>
+									</tr>
+								</thead>
+								<tbody>
+									{% for summary in monthlysummary_display_data %}
+									<tr>
+										<td>{{ summary.year }}-{{ "{:02d}".format(summary.month) }} ({{ summary.month_name }})</td>
+										<td>{{ '{:,.0f}'.format(summary.meters) if summary.meters is not none else '0' }} m</td>
+										<td>
+											{{ summary.seconds | format_total_seconds_human_readable if summary.seconds is not none else 'N/A' }}
+										</td>
+										<td>
+											{{ summary.split | format_split_short if summary.split is not none and summary.split > 0 else 'N/A' }}
+										</td>
+										<td>
+											{{ '{:,.0f}'.format(summary.isoreps) if summary.isoreps is not none else '0' }}
+										</td>
+										<td>
+											<a href="{{ url_for('workouts_by_month_detail', year_month_str=summary.year~'-'~'{:02d}'.format(summary.month)) }}">
+												<i class="fas fa-eye"></i> Details
+											</a>
+										</td>
+									</tr>
+									{% endfor %}
+								</tbody>
+							</table>
+						</div>
+					</article>
+				{% else %}							
+					<article class="box post post-excerpt">
+						<div class="box alert-info" style="font-size: 1.3em; border: 1px solid; padding: 16px; margin-bottom: 20px; text-align: center;">
+							No monthly totals found.
+						</div>
+					</article>
+				{% endif %}
+
+				<!-- -- Pagination Section ------------------- -->
+				{% if monthlysummary_pagination and monthlysummary_pagination.pages > 1 %}
+					<div class="pagination">
+						{% if monthlysummary_pagination.has_prev %}
+							<a href="{{ url_for('monthlysummary_paginated', page_num=monthlysummary_pagination.prev_num) }}"
+							   class="button previous">Previous Page</a>
+						{% else %}
+							<span class="button previous disabled" aria-disabled="true">Previous Page</span>
+						{% endif %}
+						
+						<div class="pages">
+							{% for page in monthlysummary_pagination.iter_pages(left_edge=1, right_edge=1, left_current=2, right_current=2) %}
+								{% if page %}
+									<a href="{{ url_for('monthlysummary_paginated', page_num=page) }}"
+									   class="{% if page == monthlysummary_pagination.page %}active{% endif %}">{{ page }}</a>
+								{% else %}
+									<span>…</span>
+								{% endif %}
+							{% endfor %}
+						</div>
+						
+						{% if monthlysummary_pagination.has_next %}
+							<a href="{{ url_for('monthlysummary_paginated', page_num=monthlysummary_pagination.next_num) }}"
+							   class="button next">Next Page</a>
+						{% else %}
+							<span class="button next disabled" aria-disabled="true">Next Page</span>
+						{% endif %}
+					</div>
+				{% endif %}
+			</div>
+		</div>
+		<!-- == Sidebar Inclusion ============================================ -->
+		{% include '_sidebar.html' %}
+
+		<!-- == Scripts ============================================ -->
+		<script src="{{ url_for('static', filename='js/jquery.min.js') }}"></script>
+		<script src="{{ url_for('static', filename='js/browser.min.js') }}"></script>
+		<script src="{{ url_for('static', filename='js/breakpoints.min.js') }}"></script>
+		<script src="{{ url_for('static', filename='js/util.js') }}"></script>
+		<script src="{{ url_for('static', filename='js/main.js') }}"></script>
+	</body>
+</html>

--- a/templates/weeklysummary.html
+++ b/templates/weeklysummary.html
@@ -1,0 +1,125 @@
+<!-- ======================================================== -->
+<!-- = weeklysummary.html - Template for displaying weekly workout summaries -->
+<!-- ======================================================== -->
+<!DOCTYPE HTML>
+<html>
+	<head>
+		<title>{{ page_title | default('Weekly Workout Totals') }}</title>
+		<meta charset="utf-8" />
+		<meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no" />
+		<link rel="icon" href="{{ url_for('static', filename='favicon.ico') }}">
+		<link rel="stylesheet" href="{{ url_for('static', filename='css/main.css') }}" />
+		<link rel="stylesheet" href="{{ url_for('static', filename='css/mystyles.css') }}" />
+	</head>
+	<body class="is-preload">
+
+		<!-- == Main Content Area ============================================ -->
+		<div id="content" class="custom-fullwidth">
+			<div class="inner">
+				<!-- -- Page Header ------------------- -->
+				<h1 class="extra_h1">{{ page_title | default('Weekly Summary') }}</h1>
+				<hr class="extra_title_line">
+
+				<!-- -- Flash Messages Section ------------------- -->
+				{% with messages = get_flashed_messages(with_categories=true) %}
+					{% if messages %}
+						<article class="box post post-excerpt">
+						{% for category, message in messages %}
+							<div class="box alert-{{ category }}" style="font-size: 1.3em; border: 1px solid; padding: 16px; margin-bottom: 20px; text-align: center;">
+								{{ message }}
+							</div>
+						{% endfor %}
+						</article>
+					{% endif %}
+				{% endwith %}
+					
+				<!-- -- Weekly Totals Table Section ------------------- -->
+				{% if weeklysummary_display_data %}
+					<article class="box post post-excerpt">
+						<div class="table-wrapper">
+							<table>
+								<thead>
+									<tr>
+										<th>Week (YYYY-Www)</th>
+										<th>Distance</th>
+										<th>Duration</th>
+										<th>Avg. Split</th>
+										<th>Total IsoReps</th>
+										<th>Actions</th>
+									</tr>
+								</thead>
+								<tbody>
+									{% for summary in weeklysummary_display_data %}
+									<tr>
+										<td>{{ summary.year }}-W{{ "{:02d}".format(summary.week_number) }}</td>
+										<td>{{ '{:,.0f}'.format(summary.meters) if summary.meters is not none else '0' }} m</td>
+										<td>
+											{{ summary.seconds | format_total_seconds_human_readable if summary.seconds is not none else 'N/A' }}
+										</td>
+										<td>
+											{{ summary.split | format_split_short if summary.split is not none and summary.split > 0 else 'N/A' }}
+										</td>
+										<td>
+											{{ '{:,.0f}'.format(summary.isoreps) if summary.isoreps is not none else '0' }}
+										</td>
+										<td>
+											<a href="{{ url_for('workouts_by_week_detail', year_week_str=summary.year~'-W'~'{:02d}'.format(summary.week_number)) if summary.year and summary.week_number is not none else '#' }}">
+												<i class="fas fa-eye"></i> Details
+											</a>
+										</td>
+									</tr>
+									{% endfor %}
+								</tbody>
+							</table>
+						</div>
+					</article>
+				{% else %}							
+					<article class="box post post-excerpt">
+						<div class="box alert-info" style="font-size: 1.3em; border: 1px solid; padding: 16px; margin-bottom: 20px; text-align: center;">
+							No weekly totals found.
+						</div>
+					</article>
+				{% endif %}
+
+				<!-- -- Pagination Section ------------------- -->
+				{% if weeklysummary_pagination and weeklysummary_pagination.pages > 1 %}
+					<div class="pagination">
+						{% if weeklysummary_pagination.has_prev %}
+							<a href="{{ url_for('weeklysummary_paginated', page_num=weeklysummary_pagination.prev_num) }}"
+							   class="button previous">Previous Page</a>
+						{% else %}
+							<span class="button previous disabled" aria-disabled="true">Previous Page</span>
+						{% endif %}
+						
+						<div class="pages">
+							{% for page in weeklysummary_pagination.iter_pages(left_edge=1, right_edge=1, left_current=2, right_current=2) %}
+								{% if page %}
+									<a href="{{ url_for('weeklysummary_paginated', page_num=page) }}"
+									   class="{% if page == weeklysummary_pagination.page %}active{% endif %}">{{ page }}</a>
+								{% else %}
+									<span>…</span>
+								{% endif %}
+							{% endfor %}
+						</div>
+						
+						{% if weeklysummary_pagination.has_next %}
+							<a href="{{ url_for('weeklysummary_paginated', page_num=weeklysummary_pagination.next_num) }}"
+							   class="button next">Next Page</a>
+						{% else %}
+							<span class="button next disabled" aria-disabled="true">Next Page</span>
+						{% endif %}
+					</div>
+				{% endif %}
+			</div>
+		</div>
+		<!-- == Sidebar Inclusion ============================================ -->
+		{% include '_sidebar.html' %}
+
+		<!-- == Scripts ============================================ -->
+		<script src="{{ url_for('static', filename='js/jquery.min.js') }}"></script>
+		<script src="{{ url_for('static', filename='js/browser.min.js') }}"></script>
+		<script src="{{ url_for('static', filename='js/breakpoints.min.js') }}"></script>
+		<script src="{{ url_for('static', filename='js/util.js') }}"></script>
+		<script src="{{ url_for('static', filename='js/main.js') }}"></script>
+	</body>
+</html>

--- a/templates/workouts.html
+++ b/templates/workouts.html
@@ -1,120 +1,125 @@
-<!-- templates/workouts.html -->
+<!-- ======================================================== -->
+<!-- = workouts.html - Template for displaying a list of workouts -->
+<!-- ======================================================== -->
 <!DOCTYPE HTML>
 <html>
 	<head>
-		<title>RowErg Diary - Workouts</title> <!-- Changed Title -->
+		<title>RowErg Diary - Workouts</title> <!-- Page Title -->
 		<meta charset="utf-8" />
 		<meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no" />
-		<link rel="icon" href="{{ url_for('static', filename='favicon.ico') }}">
-		<link rel="stylesheet" href="{{ url_for('static', filename='css/main.css') }}" />
-		<link rel="stylesheet" href="{{ url_for('static', filename='css/mystyles.css') }}" />
+		<link rel="icon" href="{{ url_for('static', filename='favicon.ico') }}"> <!-- Favicon Link -->
+		<link rel="stylesheet" href="{{ url_for('static', filename='css/main.css') }}" /> <!-- Main Stylesheet -->
+		<link rel="stylesheet" href="{{ url_for('static', filename='css/mystyles.css') }}" /> <!-- Custom Stylesheet -->
 	</head>
 	<body class="is-preload">
 
-		<!-- Content -->
-			<div id="content" class="custom-fullwidth">
-				<div class="inner">
-                    <h1 class="extra_h1">Workouts</h1>
-                    <hr class="extra_title_line">
-					<!-- flash messages -->
-						{% with messages = get_flashed_messages(with_categories=true) %}
-							{% if messages %}
-								<article class="box post post-excerpt">
-								{% for category, message in messages %}
-									<div class="box alert-{{ category }}" style="font-size: 1.3em; border: 1px solid; padding: 16px; margin-bottom: 20px; text-align: center;">
-										{{ message }}
-									</div>
-								{% endfor %}
-								</article>
-							{% endif %}
-						{% endwith %}
-					
-					<!-- Workouts Table -->
-						{% if workouts_display_data %}
-							<article class="box post post-excerpt">
-								<table>
-									<thead>
-										<tr>
-											<th>Date</th>
-                                            <th>Name</th>
-											<th>Distance</th>
-											<th>Duration</th>
-											<th>Split</th>
-											<th>Actions</th>
-										</tr>
-									</thead>
-									<tbody>
-										{% for item_data in workouts_display_data %}
-										<tr>
-											<td>{{ item_data.workout_obj.workout_date.strftime('%Y-%m-%d') if item_data.workout_obj.workout_date else 'N/A' }}</td>
-                                            <td><a href="{{ url_for('details', workout_id=item_data.workout_obj.workout_id) }}">{{ item_data.workout_obj.workout_name | default('Unnamed Workout') }}</a></td>
-											
-                                            {# Assuming views/workouts.py now provides formatted strings in item_data.summary #}
-                                            {# If views/workouts.py provides raw numbers for workout_obj, use filters: #}
-                                            <td>{{ '{:,.0f}'.format(item_data.workout_obj.total_distance_meters) if item_data.workout_obj.total_distance_meters is not none else 'N/A' }} m</td>
-                                            <td>{{ item_data.workout_obj.duration_seconds | format_total_seconds_human_readable }}</td>
-                                            <td>{{ item_data.workout_obj.average_split_seconds_500m | format_split_ms }}</td>
-											
-                                            <td>
-												<a href="{{ url_for('details', workout_id=item_data.workout_obj.workout_id) }}">
-													<i class="fas fa-eye"></i> Details
-												</a>
-											</td>
-										</tr>
-										{% endfor %}
-									</tbody>
-								</table>
-							</article>
-							
-						{% else %}								
-								<article class="box post post-excerpt">
-									<div class="box alert-info" style="font-size: 1.3em; border: 1px solid; padding: 16px; margin-bottom: 20px; text-align: center;">
-										No workouts found.
-									</div>
-								</article>
-							<p></p>
-						{% endif %}
+		<!-- == Main Content Area ============================================ -->
+		<div id="content" class="custom-fullwidth">
+			<div class="inner">
+				<!-- -- Page Header ------------------- -->
+				<h1 class="extra_h1">Workouts</h1>
+				<hr class="extra_title_line">
 
-					<!-- Pagination (structure unchanged) -->
-					{% if workouts_pagination.pages > 1 %}
-						<div class="pagination">
-                            <!-- ... pagination buttons ... -->
-							{% if workouts_pagination.has_prev %}
-								<a href="{{ url_for('workouts_paginated', page_num=workouts_pagination.prev_num) }}"
-								   class="button previous">Previous Page</a>
-							{% else %}
-								<span class="button previous disabled" aria-disabled="true">Previous Page</span>
-							{% endif %}
-							
-							<div class="pages">
-								{% for page in workouts_pagination.iter_pages(left_edge=1, right_edge=1, left_current=2, right_current=2) %}
-									{% if page %}
-										<a href="{{ url_for('workouts_paginated', page_num=page) }}"
-										   class="{% if page == workouts_pagination.page %}active{% endif %}">{{ page }}</a>
-									{% else %}
-										<span>…</span>
-									{% endif %}
-								{% endfor %}
+				<!-- -- Flash Messages Section ------------------- -->
+				{% with messages = get_flashed_messages(with_categories=true) %}
+					{% if messages %}
+						<article class="box post post-excerpt">
+						{% for category, message in messages %}
+							<div class="box alert-{{ category }}" style="font-size: 1.3em; border: 1px solid; padding: 16px; margin-bottom: 20px; text-align: center;">
+								{{ message }} <!-- Display flash message -->
 							</div>
-							
-							{% if workouts_pagination.has_next %}
-								<a href="{{ url_for('workouts_paginated', page_num=workouts_pagination.next_num) }}"
-								   class="button next">Next Page</a>
-							{% else %}
-								<span class="button next disabled" aria-disabled="true">Next Page</span>
-							{% endif %}
-						</div>
+						{% endfor %}
+						</article>
 					{% endif %}
-				</div>
-			</div>
-		<!-- Sidebar -->
-			{% include '_sidebar.html' %}
+				{% endwith %}
+				
+				<!-- -- Workouts Table Section ------------------- -->
+				{% if workouts_display_data %} <!-- Check if there are workouts to display -->
+					<article class="box post post-excerpt">
+						<table>
+							<thead>
+								<tr>
+									<th>Date</th>
+									<th>Name</th>
+									<th>Distance</th>
+									<th>Duration</th>
+									<th>Split</th>
+									<th>Actions</th>
+								</tr>
+							</thead>
+							<tbody>
+								{% for item_data in workouts_display_data %} <!-- Loop through each workout -->
+								<tr>
+									<td>{{ item_data.workout_obj.workout_date.strftime('%Y-%m-%d') if item_data.workout_obj.workout_date else 'N/A' }}</td> <!-- Workout Date -->
+									<td><a href="{{ url_for('details', workout_id=item_data.workout_obj.workout_id) }}">{{ item_data.workout_obj.workout_name | default('Unnamed Workout') }}</a></td> <!-- Workout Name (link to details) -->
+									
+									<!-- Data cells using Jinja filters for formatting -->
+									<td>{{ '{:,.0f}'.format(item_data.workout_obj.total_distance_meters) if item_data.workout_obj.total_distance_meters is not none else 'N/A' }} m</td> <!-- Total Distance -->
+									<td>{{ item_data.workout_obj.duration_seconds | format_total_seconds_human_readable }}</td> <!-- Duration -->
+									<td>{{ item_data.workout_obj.average_split_seconds_500m | format_split_ms }}</td> <!-- Average Split -->
+									
+									<td>
+										<a href="{{ url_for('details', workout_id=item_data.workout_obj.workout_id) }}">
+											<i class="fas fa-eye"></i> Details <!-- Link to workout details page -->
+										</a>
+									</td>
+								</tr>
+								{% endfor %}
+							</tbody>
+						</table>
+					</article>
+					
+				{% else %} <!-- If no workouts are found -->							
+					<article class="box post post-excerpt">
+						<div class="box alert-info" style="font-size: 1.3em; border: 1px solid; padding: 16px; margin-bottom: 20px; text-align: center;">
+							No workouts found. <!-- Message indicating no workouts -->
+						</div>
+					</article>
+					<p></p>
+				{% endif %}
 
-		<!-- Scripts -->
-			<script src="{{ url_for('static', filename='js/jquery.min.js') }}"></script>
-			<script src="{{ url_for('static', filename='js/browser.min.js') }}"></script>
-			<script src="{{ url_for('static', filename='js/breakpoints.min.js') }}"></script>
-			<script src="{{ url_for('static', filename='js/util.js') }}"></script>
-			<script src="{{ url_for('static', filename='js/main.js') }}"></script>
+				<!-- -- Pagination Section ------------------- -->
+				{% if workouts_pagination.pages > 1 %} <!-- Check if pagination is needed -->
+					<div class="pagination">
+						<!-- Previous Page Button -->
+						{% if workouts_pagination.has_prev %}
+							<a href="{{ url_for('workouts_paginated', page_num=workouts_pagination.prev_num) }}"
+							   class="button previous">Previous Page</a>
+						{% else %}
+							<span class="button previous disabled" aria-disabled="true">Previous Page</span>
+						{% endif %}
+						
+						<!-- Page Numbers -->
+						<div class="pages">
+							{% for page in workouts_pagination.iter_pages(left_edge=1, right_edge=1, left_current=2, right_current=2) %}
+								{% if page %}
+									<a href="{{ url_for('workouts_paginated', page_num=page) }}"
+									   class="{% if page == workouts_pagination.page %}active{% endif %}">{{ page }}</a>
+								{% else %}
+									<span>…</span> <!-- Ellipsis for skipped pages -->
+								{% endif %}
+							{% endfor %}
+						</div>
+						
+						<!-- Next Page Button -->
+						{% if workouts_pagination.has_next %}
+							<a href="{{ url_for('workouts_paginated', page_num=workouts_pagination.next_num) }}"
+							   class="button next">Next Page</a>
+						{% else %}
+							<span class="button next disabled" aria-disabled="true">Next Page</span>
+						{% endif %}
+					</div>
+				{% endif %}
+			</div>
+		</div>
+		<!-- == Sidebar Inclusion ============================================ -->
+		{% include '_sidebar.html' %} <!-- Include the sidebar template -->
+
+		<!-- == Scripts ============================================ -->
+		<script src="{{ url_for('static', filename='js/jquery.min.js') }}"></script>
+		<script src="{{ url_for('static', filename='js/browser.min.js') }}"></script>
+		<script src="{{ url_for('static', filename='js/breakpoints.min.js') }}"></script>
+		<script src="{{ url_for('static', filename='js/util.js') }}"></script>
+		<script src="{{ url_for('static', filename='js/main.js') }}"></script>
 	</body>
 </html>

--- a/templates/workouts_by_date.html
+++ b/templates/workouts_by_date.html
@@ -60,11 +60,19 @@
 									</td>
 								</tr>
 								<tr>
-									<td style="padding: 8px;">Average Split (/500m):</td>
-									<td style="padding: 8px; text-align: right;">
+									<td style="padding: 8px; border-bottom: 1px solid #eee;">Average Split (/500m):</td>
+									<td style="padding: 8px; border-bottom: 1px solid #eee; text-align: right;">
 										{{ daily_summary_data.split | format_split_short if daily_summary_data.split is not none and daily_summary_data.split > 0 else 'N/A' }} <!-- Formatted Average Split -->
 									</td>
 								</tr>
+								{% if daily_summary_data.isoreps and daily_summary_data.isoreps > 0 %}
+								<tr>
+									<td style="padding: 8px;">Total IsoReps:</td>
+									<td style="padding: 8px; text-align: right;">
+										{{ '{:,.0f}'.format(daily_summary_data.isoreps) }}
+									</td>
+								</tr>
+								{% endif %}
 							</tbody>
 						</table>
 					</article>

--- a/templates/workouts_by_date.html
+++ b/templates/workouts_by_date.html
@@ -1,136 +1,137 @@
-<!-- templates/workouts_by_date.html -->
+<!-- ======================================================== -->
+<!-- = workouts_by_date.html - Template for displaying workouts for a specific date -->
+<!-- ======================================================== -->
 <!DOCTYPE HTML>
 <html>
 	<head>
-		<title>Workouts on {{ selected_date_str | default('Selected Date') }}</title>
+		<title>Workouts on {{ selected_date_str | default('Selected Date') }}</title> <!-- Page Title, dynamically set with the selected date -->
 		<meta charset="utf-8" />
 		<meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no" />
-		<link rel="icon" href="{{ url_for('static', filename='favicon.ico') }}">
-		<link rel="stylesheet" href="{{ url_for('static', filename='css/main.css') }}" />
-		<link rel="stylesheet" href="{{ url_for('static', filename='css/mystyles.css') }}" />
+		<link rel="icon" href="{{ url_for('static', filename='favicon.ico') }}"> <!-- Favicon Link -->
+		<link rel="stylesheet" href="{{ url_for('static', filename='css/main.css') }}" /> <!-- Main Stylesheet -->
+		<link rel="stylesheet" href="{{ url_for('static', filename='css/mystyles.css') }}" /> <!-- Custom Stylesheet -->
 	</head>
 	<body class="is-preload">
 
-		<!-- Content -->
-			<div id="content" class="custom-fullwidth">
-				<div class="inner">
-                    <h1 class="extra_h1">Workouts on {{ selected_date_str | default('Selected Date') }}</h1>
-                    <hr class="extra_title_line">
+		<!-- == Main Content Area ============================================ -->
+		<div id="content" class="custom-fullwidth">
+			<div class="inner">
+				<!-- -- Page Header ------------------- -->
+				<h1 class="extra_h1">Workouts on {{ selected_date_str | default('Selected Date') }}</h1> <!-- Dynamic Page Header -->
+				<hr class="extra_title_line">
 
-					<!-- flash messages -->
-						{% with messages = get_flashed_messages(with_categories=true) %}
-							{% if messages %}
-								<article class="box post post-excerpt">
-								{% for category, message in messages %}
-									<div class="box alert-{{ category }}" style="font-size: 1.3em; border: 1px solid; padding: 16px; margin-bottom: 20px; text-align: center;">
-										{{ message }}
-									</div>
-								{% endfor %}
-								</article>
-							{% endif %}
-						{% endwith %}
-
-                    <!-- Daily Summary for Selected Date -->
-					{% if daily_summary_data %}
+				<!-- -- Flash Messages Section ------------------- -->
+				{% with messages = get_flashed_messages(with_categories=true) %}
+					{% if messages %}
 						<article class="box post post-excerpt">
-							<header style="margin-bottom: 10px; padding-top: 0px;">
-								<h3 style="margin-bottom: 5px; color: #555;">Summary for {{ selected_date_str }}</h3>
-							</header>
-							<table style="width: 100%; margin-bottom: 20px;">
-								<thead>
-									<tr>
-										<th style="text-align: left; padding: 8px; background-color: #f4f7fb;">Metric</th>
-										<th style="text-align: right; padding: 8px; background-color: #f4f7fb;">Total</th>
-									</tr>
-								</thead>
-								<tbody>
-									<tr>
-										<td style="padding: 8px; border-bottom: 1px solid #eee;">Total Distance:</td>
-										<td style="padding: 8px; border-bottom: 1px solid #eee; text-align: right;">
-											{{ '{:,.0f}'.format(daily_summary_data.meters) if daily_summary_data.meters is not none else '0' }} m
-										</td>
-									</tr>
-									<tr>
-										<td style="padding: 8px; border-bottom: 1px solid #eee;">Total Duration:</td>
-										<td style="padding: 8px; border-bottom: 1px solid #eee; text-align: right;">
-											{{ daily_summary_data.seconds | format_total_seconds_human_readable if daily_summary_data.seconds is not none else 'N/A' }}
-										</td>
-									</tr>
-									<tr>
-										<td style="padding: 8px;">Average Split (/500m):</td>
-										<td style="padding: 8px; text-align: right;">
-											{{ daily_summary_data.split | format_split_short if daily_summary_data.split is not none and daily_summary_data.split > 0 else 'N/A' }}
-										</td>
-									</tr>
-								</tbody>
-							</table>
+						{% for category, message in messages %}
+							<div class="box alert-{{ category }}" style="font-size: 1.3em; border: 1px solid; padding: 16px; margin-bottom: 20px; text-align: center;">
+								{{ message }} <!-- Display flash message -->
+							</div>
+						{% endfor %}
 						</article>
-						<hr class="extra_article"> {# Optional: to separate summary from workout list #}
 					{% endif %}
+				{% endwith %}
 
-					<!-- Workouts -->
-						{% if workouts_display_data %}
-							{% for item_data in workouts_display_data %}
-								{# This article structure is similar to index.html for consistency #}
-								{% if not loop.first %}<hr class="extra_article">{% endif %}
-								<article class="box post post-excerpt">
-									<header style="margin-bottom: 0px; padding-top: 0px;">
-										<h2 style="margin-bottom: 5px;"><a href="{{ url_for('details', workout_id=item_data.workout_obj.workout_id) }}">{{ item_data.name | default('Unnamed Workout') }}</a></h2>
-									</header>
-                                        {# Date display for each workout might be redundant here since all are for the same day, #}
-                                        {# but kept for consistency with index.html's article layout. #}
-                                        {# You could simplify this if desired or show workout time if available. #}
-                                        <table class="workout-stats-table" style="width:auto; margin-bottom: 0.5em;">
-                                            <tr>
-                                                <th>Distance</th>
-                                                <th>Time</th>
-                                                <th>Split</th>
-                                            </tr>
-                                            <tr>
-                                                <td>
-                                                    <span class="icon distance"></span>
-                                                    {{ '{:,.0f}'.format(item_data.workout_obj.total_distance_meters) if item_data.workout_obj.total_distance_meters is not none else 'N/A' }} m
-                                                </td>
-                                                <td>
-                                                    <span class="icon time"></span>
-                                                    {{ item_data.workout_obj.duration_seconds | format_total_seconds_human_readable }}
-                                                </td>
-                                                <td>
-                                                    <span class="icon split"></span>
-                                                    {{ item_data.workout_obj.average_split_seconds_500m | format_split_ms }}
-                                                </td>
-                                            </tr>
-                                        </table>
+				<!-- -- Daily Summary for Selected Date Section ------------------- -->
+				{% if daily_summary_data %} <!-- Check if daily summary data is available -->
+					<article class="box post post-excerpt">
+						<header style="margin-bottom: 10px; padding-top: 0px;">
+							<h3 style="margin-bottom: 5px; color: #555;">Summary for {{ selected_date_str }}</h3> <!-- Summary Sub-header -->
+						</header>
+						<table style="width: 100%; margin-bottom: 20px;">
+							<thead>
+								<tr>
+									<th style="text-align: left; padding: 8px; background-color: #f4f7fb;">Metric</th>
+									<th style="text-align: right; padding: 8px; background-color: #f4f7fb;">Total</th>
+								</tr>
+							</thead>
+							<tbody>
+								<tr>
+									<td style="padding: 8px; border-bottom: 1px solid #eee;">Total Distance:</td>
+									<td style="padding: 8px; border-bottom: 1px solid #eee; text-align: right;">
+										{{ '{:,.0f}'.format(daily_summary_data.meters) if daily_summary_data.meters is not none else '0' }} m <!-- Formatted Total Distance -->
+									</td>
+								</tr>
+								<tr>
+									<td style="padding: 8px; border-bottom: 1px solid #eee;">Total Duration:</td>
+									<td style="padding: 8px; border-bottom: 1px solid #eee; text-align: right;">
+										{{ daily_summary_data.seconds | format_total_seconds_human_readable if daily_summary_data.seconds is not none else 'N/A' }} <!-- Formatted Total Duration -->
+									</td>
+								</tr>
+								<tr>
+									<td style="padding: 8px;">Average Split (/500m):</td>
+									<td style="padding: 8px; text-align: right;">
+										{{ daily_summary_data.split | format_split_short if daily_summary_data.split is not none and daily_summary_data.split > 0 else 'N/A' }} <!-- Formatted Average Split -->
+									</td>
+								</tr>
+							</tbody>
+						</table>
+					</article>
+					<hr class="extra_article"> <!-- Separator line -->
+				{% endif %}
 
-									<div id="workout-graph-placeholder-{{ item_data.workout_obj.workout_id }}" style="width:100%; height:250px; background:#f4f7fb; border:1px dashed #b3c6e7; display:flex; align-items:center; justify-content:center; margin: 0px 0;">
-										<span style="color:#6a8fd7; font-size:1.2em;">[ Graph for {{ item_data.workout_obj.workout_name | default('Workout') }} (ID: {{ item_data.workout_obj.workout_id }}) ]</span>
-									</div>
-								</article>
-							{% endfor %}
-						{% else %}								
-							<article class="box post post-excerpt">
-								<div class="box alert-info" style="font-size: 1.3em; border: 1px solid; padding: 16px; margin-bottom: 20px; text-align: center;">
-									No workouts found for this date.
-								</div>
-							</article>
-						{% endif %}
+				<!-- -- Individual Workouts List Section ------------------- -->
+				{% if workouts_display_data %} <!-- Check if there are workouts to display for the date -->
+					{% for item_data in workouts_display_data %} <!-- Loop through each workout -->
+						{% if not loop.first %}<hr class="extra_article">{% endif %} <!-- Add separator between workouts -->
+						<article class="box post post-excerpt">
+							<header style="margin-bottom: 0px; padding-top: 0px;">
+								<h2 style="margin-bottom: 5px;"><a href="{{ url_for('details', workout_id=item_data.workout_obj.workout_id) }}">{{ item_data.name | default('Unnamed Workout') }}</a></h2> <!-- Workout Name (link to details) -->
+							</header>
+							<!-- Workout Stats Table -->
+							<table class="workout-stats-table" style="width:auto; margin-bottom: 0.5em;">
+								<tr>
+									<th>Distance</th>
+									<th>Time</th>
+									<th>Split</th>
+								</tr>
+								<tr>
+									<td>
+										<span class="icon distance"></span> <!-- Distance Icon (assuming CSS handles this) -->
+										{{ '{:,.0f}'.format(item_data.workout_obj.total_distance_meters) if item_data.workout_obj.total_distance_meters is not none else 'N/A' }} m <!-- Formatted Distance -->
+									</td>
+									<td>
+										<span class="icon time"></span> <!-- Time Icon -->
+										{{ item_data.workout_obj.duration_seconds | format_total_seconds_human_readable }} <!-- Formatted Duration -->
+									</td>
+									<td>
+										<span class="icon split"></span> <!-- Split Icon -->
+										{{ item_data.workout_obj.average_split_seconds_500m | format_split_ms }} <!-- Formatted Split -->
+									</td>
+								</tr>
+							</table>
 
-                    <!-- Back Link -->
-                    <div style="text-align: center; margin-top: 30px;">
-                        <a href="{{ url_for('dailysummary') }}" class="button">
-                            ← Back to Daily Summary
-                        </a>
-                    </div>
+							<!-- Placeholder for Workout Graph -->
+							<div id="workout-graph-placeholder-{{ item_data.workout_obj.workout_id }}" style="width:100%; height:250px; background:#f4f7fb; border:1px dashed #b3c6e7; display:flex; align-items:center; justify-content:center; margin: 0px 0;">
+								<span style="color:#6a8fd7; font-size:1.2em;">[ Graph for {{ item_data.workout_obj.workout_name | default('Workout') }} (ID: {{ item_data.workout_obj.workout_id }}) ]</span>
+							</div>
+						</article>
+					{% endfor %}
+				{% else %} <!-- If no workouts are found for this date -->							
+					<article class="box post post-excerpt">
+						<div class="box alert-info" style="font-size: 1.3em; border: 1px solid; padding: 16px; margin-bottom: 20px; text-align: center;">
+							No workouts found for this date. <!-- Message indicating no workouts -->
+						</div>
+					</article>
+				{% endif %}
+
+				<!-- -- Back Link Section ------------------- -->
+				<div style="text-align: center; margin-top: 30px;">
+					<a href="{{ url_for('dailysummary') }}" class="button">
+						← Back to Daily Summary <!-- Link to return to the main daily summary page -->
+					</a>
 				</div>
 			</div>
-		<!-- Sidebar -->
-			{% include '_sidebar.html' %}
+		</div>
+		<!-- == Sidebar Inclusion ============================================ -->
+		{% include '_sidebar.html' %} <!-- Include the sidebar template -->
 
-		<!-- Scripts -->
-			<script src="{{ url_for('static', filename='js/jquery.min.js') }}"></script>
-			<script src="{{ url_for('static', filename='js/browser.min.js') }}"></script>
-			<script src="{{ url_for('static', filename='js/breakpoints.min.js') }}"></script>
-			<script src="{{ url_for('static', filename='js/util.js') }}"></script>
-			<script src="{{ url_for('static', filename='js/main.js') }}"></script>
+		<!-- == Scripts ============================================ -->
+		<script src="{{ url_for('static', filename='js/jquery.min.js') }}"></script>
+		<script src="{{ url_for('static', filename='js/browser.min.js') }}"></script>
+		<script src="{{ url_for('static', filename='js/breakpoints.min.js') }}"></script>
+		<script src="{{ url_for('static', filename='js/util.js') }}"></script>
+		<script src="{{ url_for('static', filename='js/main.js') }}"></script>
 	</body>
 </html>

--- a/templates/workouts_by_month.html
+++ b/templates/workouts_by_month.html
@@ -1,0 +1,202 @@
+<!-- ======================================================== -->
+<!-- = workouts_by_month.html - Template for displaying workouts for a specific month -->
+<!-- ======================================================== -->
+<!DOCTYPE HTML>
+<html>
+	<head>
+		<title>Workouts for {{ selected_month_str | default('Selected Month') }}</title>
+		<meta charset="utf-8" />
+		<meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no" />
+		<link rel="icon" href="{{ url_for('static', filename='favicon.ico') }}">
+		<link rel="stylesheet" href="{{ url_for('static', filename='css/main.css') }}" />
+		<link rel="stylesheet" href="{{ url_for('static', filename='css/mystyles.css') }}" />
+	</head>
+	<body class="is-preload">
+
+		<!-- == Main Content Area ============================================ -->
+		<div id="content" class="custom-fullwidth">
+			<div class="inner">
+				<!-- -- Page Header ------------------- -->
+				<h1 class="extra_h1">Workout Details for {{ selected_month_str | default('Selected Month') }}</h1>
+				<hr class="extra_title_line">
+
+				<!-- -- Flash Messages Section ------------------- -->
+				{% with messages = get_flashed_messages(with_categories=true) %}
+					{% if messages %}
+						<article class="box post post-excerpt">
+						{% for category, message in messages %}
+							<div class="box alert-{{ category }}" style="font-size: 1.3em; border: 1px solid; padding: 16px; margin-bottom: 20px; text-align: center;">
+								{{ message }}
+							</div>
+						{% endfor %}
+						</article>
+					{% endif %}
+				{% endwith %}
+
+				<!-- -- Overall Monthly Summary Section ------------------- -->
+				{% if month_summary_data %}
+					<article class="box post post-excerpt">
+						<header style="margin-bottom: 10px; padding-top: 0px;">
+							<h3 style="margin-bottom: 5px; color: #555;">Overall Summary for {{ selected_month_str }}</h3>
+						</header>
+						<table style="width: 100%; margin-bottom: 20px;">
+							<thead>
+								<tr>
+									<th style="text-align: left; padding: 8px; background-color: #f4f7fb;">Metric</th>
+									<th style="text-align: right; padding: 8px; background-color: #f4f7fb;">Total</th>
+								</tr>
+							</thead>
+							<tbody>
+								<tr>
+									<td style="padding: 8px; border-bottom: 1px solid #eee;">Total Distance:</td>
+									<td style="padding: 8px; border-bottom: 1px solid #eee; text-align: right;">
+										{{ '{:,.0f}'.format(month_summary_data.meters) if month_summary_data.meters is not none else '0' }} m
+									</td>
+								</tr>
+								<tr>
+									<td style="padding: 8px; border-bottom: 1px solid #eee;">Total Duration:</td>
+									<td style="padding: 8px; border-bottom: 1px solid #eee; text-align: right;">
+										{{ month_summary_data.seconds | format_total_seconds_human_readable if month_summary_data.seconds is not none else 'N/A' }}
+									</td>
+								</tr>
+								<tr>
+									<td style="padding: 8px; border-bottom: 1px solid #eee;">Average Split (/500m):</td>
+									<td style="padding: 8px; border-bottom: 1px solid #eee; text-align: right;">
+										{{ month_summary_data.split | format_split_short if month_summary_data.split is not none and month_summary_data.split > 0 else 'N/A' }}
+									</td>
+								</tr>
+								{% if month_summary_data.isoreps and month_summary_data.isoreps > 0 %}
+								<tr>
+									<td style="padding: 8px;">Total IsoReps:</td>
+									<td style="padding: 8px; text-align: right;">
+										{{ '{:,.0f}'.format(month_summary_data.isoreps) }}
+									</td>
+								</tr>
+								{% endif %}
+							</tbody>
+						</table>
+					</article>
+					<hr class="extra_article"> 
+				{% endif %}
+
+				<!-- -- Weekly Summaries in Month Section ------------------- -->
+				{% if weekly_summaries_in_month %}
+					<article class="box post post-excerpt">
+						<header style="margin-bottom: 10px; padding-top: 0px;">
+							<h3 style="margin-bottom: 5px; color: #555;">Weekly Breakdown</h3>
+						</header>
+						<div class="table-wrapper">
+							<table>
+								<thead>
+									<tr>
+										<th>Week (YYYY-Www)</th>
+										<th>Distance</th>
+										<th>Duration</th>
+										<th>Avg. Split</th>
+										<th>Total IsoReps</th>
+										<th>Actions</th>
+									</tr>
+								</thead>
+								<tbody>
+									{% for weekly_summary in weekly_summaries_in_month %}
+									<tr>
+										<td>{{ weekly_summary.year }}-W{{ "{:02d}".format(weekly_summary.week_number) }} <br><small>({{ weekly_summary.week_start_date.strftime('%b %d') }} - {{ weekly_summary.week_end_date_display.strftime('%b %d') }})</small></td>
+										<td>{{ '{:,.0f}'.format(weekly_summary.meters) if weekly_summary.meters > 0 else '-' }} m</td>
+										<td>
+											{{ weekly_summary.seconds | format_total_seconds_human_readable if weekly_summary.seconds > 0 else '-' }}
+										</td>
+										<td>
+											{{ weekly_summary.split | format_split_short if weekly_summary.split > 0 else '-' }}
+										</td>
+										<td>
+											{{ '{:,.0f}'.format(weekly_summary.isoreps) if weekly_summary.isoreps > 0 else '-' }}
+										</td>
+										<td>
+											<a href="{{ url_for('workouts_by_week_detail', year_week_str=weekly_summary.year~'-W'~'{:02d}'.format(weekly_summary.week_number)) }}">
+												<i class="fas fa-eye"></i> Details
+											</a>
+										</td>
+									</tr>
+									{% endfor %}
+								</tbody>
+							</table>
+						</div>
+					</article>
+					<hr class="extra_article">
+				{% endif %}
+
+
+				<!-- -- Daily Summaries in Month Section ------------------- -->
+				{% if daily_summaries_in_month %}
+					<article class="box post post-excerpt">
+						<header style="margin-bottom: 10px; padding-top: 0px;">
+							<h3 style="margin-bottom: 5px; color: #555;">Daily Breakdown</h3>
+						</header>
+						<div class="table-wrapper">
+							<table>
+								<thead>
+									<tr>
+										<th>Date</th>
+										<th>Distance</th>
+										<th>Duration</th>
+										<th>Split</th>
+										<th>Total IsoReps</th>
+										<th>Actions</th>
+									</tr>
+								</thead>
+								<tbody>
+									{% for daily_summary in daily_summaries_in_month %}
+									<tr>
+										<td>{{ daily_summary.day_date.strftime('%A, %b %d') }}</td>
+										<td>{{ '{:,.0f}'.format(daily_summary.meters) if daily_summary.meters > 0 else '-' }} m</td>
+										<td>
+											{{ daily_summary.seconds | format_total_seconds_human_readable if daily_summary.seconds > 0 else '-' }}
+										</td>
+										<td>
+											{{ daily_summary.split | format_split_short if daily_summary.split > 0 else '-' }}
+										</td>
+										<td>
+											{{ '{:,.0f}'.format(daily_summary.isoreps) if daily_summary.isoreps > 0 else '-' }}
+										</td>
+										<td>
+											{% if daily_summary.has_workouts %}
+											<a href="{{ url_for('workouts_by_date', date_str=daily_summary.day_date.strftime('%Y-%m-%d')) }}">
+												<i class="fas fa-eye"></i> Details
+											</a>
+											{% else %}
+											<span style="color: #999;">No Workouts</span>
+											{% endif %}
+										</td>
+									</tr>
+									{% endfor %}
+								</tbody>
+							</table>
+						</div>
+					</article>
+				{% else %}							
+					<article class="box post post-excerpt">
+						<div class="box alert-info" style="font-size: 1.3em; border: 1px solid; padding: 16px; margin-bottom: 20px; text-align: center;">
+							No daily summary data found for this month.
+						</div>
+					</article>
+				{% endif %}
+
+				<!-- -- Back Link Section ------------------- -->
+				<div style="text-align: center; margin-top: 30px;">
+					<a href="{{ url_for('monthlysummary') }}" class="button">
+						← Back to Monthly Summary
+					</a>
+				</div>
+			</div>
+		</div>
+		<!-- == Sidebar Inclusion ============================================ -->
+		{% include '_sidebar.html' %}
+
+		<!-- == Scripts ============================================ -->
+		<script src="{{ url_for('static', filename='js/jquery.min.js') }}"></script>
+		<script src="{{ url_for('static', filename='js/browser.min.js') }}"></script>
+		<script src="{{ url_for('static', filename='js/breakpoints.min.js') }}"></script>
+		<script src="{{ url_for('static', filename='js/util.js') }}"></script>
+		<script src="{{ url_for('static', filename='js/main.js') }}"></script>
+	</body>
+</html>

--- a/templates/workouts_by_week.html
+++ b/templates/workouts_by_week.html
@@ -1,0 +1,155 @@
+<!-- ======================================================== -->
+<!-- = workouts_by_week.html - Template for displaying workouts for a specific week -->
+<!-- ======================================================== -->
+<!DOCTYPE HTML>
+<html>
+	<head>
+		<title>Workouts for {{ selected_week_str | default('Selected Week') }}</title>
+		<meta charset="utf-8" />
+		<meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no" />
+		<link rel="icon" href="{{ url_for('static', filename='favicon.ico') }}">
+		<link rel="stylesheet" href="{{ url_for('static', filename='css/main.css') }}" />
+		<link rel="stylesheet" href="{{ url_for('static', filename='css/mystyles.css') }}" />
+	</head>
+	<body class="is-preload">
+
+		<!-- == Main Content Area ============================================ -->
+		<div id="content" class="custom-fullwidth">
+			<div class="inner">
+				<!-- -- Page Header ------------------- -->
+				<h1 class="extra_h1">Workouts for {{ selected_week_str | default('Selected Week') }}</h1>
+				<hr class="extra_title_line">
+
+				<!-- -- Flash Messages Section ------------------- -->
+				{% with messages = get_flashed_messages(with_categories=true) %}
+					{% if messages %}
+						<article class="box post post-excerpt">
+						{% for category, message in messages %}
+							<div class="box alert-{{ category }}" style="font-size: 1.3em; border: 1px solid; padding: 16px; margin-bottom: 20px; text-align: center;">
+								{{ message }}
+							</div>
+						{% endfor %}
+						</article>
+					{% endif %}
+				{% endwith %}
+
+				<!-- -- Weekly Summary for Selected Week Section ------------------- -->
+				{% if week_summary_data %}
+					<article class="box post post-excerpt">
+						<header style="margin-bottom: 10px; padding-top: 0px;">
+							<h3 style="margin-bottom: 5px; color: #555;">Summary for {{ selected_week_str }}</h3>
+						</header>
+						<table style="width: 100%; margin-bottom: 20px;">
+							<thead>
+								<tr>
+									<th style="text-align: left; padding: 8px; background-color: #f4f7fb;">Metric</th>
+									<th style="text-align: right; padding: 8px; background-color: #f4f7fb;">Total</th>
+								</tr>
+							</thead>
+							<tbody>
+								<tr>
+									<td style="padding: 8px; border-bottom: 1px solid #eee;">Total Distance:</td>
+									<td style="padding: 8px; border-bottom: 1px solid #eee; text-align: right;">
+										{{ '{:,.0f}'.format(week_summary_data.meters) if week_summary_data.meters is not none else '0' }} m
+									</td>
+								</tr>
+								<tr>
+									<td style="padding: 8px; border-bottom: 1px solid #eee;">Total Duration:</td>
+									<td style="padding: 8px; border-bottom: 1px solid #eee; text-align: right;">
+										{{ week_summary_data.seconds | format_total_seconds_human_readable if week_summary_data.seconds is not none else 'N/A' }}
+									</td>
+								</tr>
+								<tr>
+									<td style="padding: 8px; border-bottom: 1px solid #eee;">Average Split (/500m):</td>
+									<td style="padding: 8px; border-bottom: 1px solid #eee; text-align: right;">
+										{{ week_summary_data.split | format_split_short if week_summary_data.split is not none and week_summary_data.split > 0 else 'N/A' }}
+									</td>
+								</tr>
+								{% if week_summary_data.isoreps and week_summary_data.isoreps > 0 %}
+								<tr>
+									<td style="padding: 8px;">Total IsoReps:</td>
+									<td style="padding: 8px; text-align: right;">
+										{{ '{:,.0f}'.format(week_summary_data.isoreps) }}
+									</td>
+								</tr>
+								{% endif %}
+							</tbody>
+						</table>
+					</article>
+					<hr class="extra_article"> 
+				{% endif %}
+
+				<!-- -- Daily Summaries in Week Section ------------------- -->
+				{% if daily_summaries_in_week %}
+					<article class="box post post-excerpt">
+						<header style="margin-bottom: 10px; padding-top: 0px;">
+							<h3 style="margin-bottom: 5px; color: #555;">Daily Breakdown</h3>
+						</header>
+						<div class="table-wrapper">
+							<table>
+								<thead>
+									<tr>
+										<th>Date</th>
+										<th>Distance</th>
+										<th>Duration</th>
+										<th>Split</th>
+										<th>Total IsoReps</th>
+										<th>Actions</th>
+									</tr>
+								</thead>
+								<tbody>
+									{% for daily_summary in daily_summaries_in_week %}
+									<tr>
+										<td>{{ daily_summary.day_date.strftime('%A, %b %d') }}</td>
+										<td>{{ '{:,.0f}'.format(daily_summary.meters) if daily_summary.meters > 0 else '-' }} m</td>
+										<td>
+											{{ daily_summary.seconds | format_total_seconds_human_readable if daily_summary.seconds > 0 else '-' }}
+										</td>
+										<td>
+											{{ daily_summary.split | format_split_short if daily_summary.split > 0 else '-' }}
+										</td>
+										<td>
+											{{ '{:,.0f}'.format(daily_summary.isoreps) if daily_summary.isoreps > 0 else '-' }}
+										</td>
+										<td>
+											{% if daily_summary.has_workouts %}
+											<a href="{{ url_for('workouts_by_date', date_str=daily_summary.day_date.strftime('%Y-%m-%d')) }}">
+												<i class="fas fa-eye"></i> Details
+											</a>
+											{% else %}
+											<span style="color: #999;">No Workouts</span>
+											{% endif %}
+										</td>
+									</tr>
+									{% endfor %}
+								</tbody>
+							</table>
+						</div>
+					</article>
+				{% else %}							
+					<article class="box post post-excerpt">
+						<div class="box alert-info" style="font-size: 1.3em; border: 1px solid; padding: 16px; margin-bottom: 20px; text-align: center;">
+							No daily summary data found for this week.
+						</div>
+					</article>
+				{% endif %}
+
+				<!-- -- Back Link Section ------------------- -->
+				<div style="text-align: center; margin-top: 30px;">
+					<a href="{{ url_for('weeklysummary') }}" class="button">
+						← Back to Weekly Summary
+					</a>
+				</div>
+			</div>
+		</div>
+		<!-- == Sidebar Inclusion ============================================ -->
+		{% include '_sidebar.html' %}
+
+		<!-- == Scripts ============================================ -->
+		<script src="{{ url_for('static', filename='js/jquery.min.js') }}"></script>
+		<script src="{{ url_for('static', filename='js/browser.min.js') }}"></script>
+		<script src="{{ url_for('static', filename='js/breakpoints.min.js') }}"></script>
+		<script src="{{ url_for('static', filename='js/util.js') }}"></script>
+		<script src="{{ url_for('static', filename='js/main.js') }}"></script>
+	</body>
+</html>

--- a/templates/workouts_by_year.html
+++ b/templates/workouts_by_year.html
@@ -1,0 +1,199 @@
+<!-- ======================================================== -->
+<!-- = workouts_by_year.html - Template for displaying workout details for a specific year -->
+<!-- ======================================================== -->
+<!DOCTYPE HTML>
+<html>
+	<head>
+		<title>Workout Details for {{ selected_year_str }}</title>
+		<meta charset="utf-8" />
+		<meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no" />
+		<link rel="icon" href="{{ url_for('static', filename='favicon.ico') }}">
+		<link rel="stylesheet" href="{{ url_for('static', filename='css/main.css') }}" />
+		<link rel="stylesheet" href="{{ url_for('static', filename='css/mystyles.css') }}" />
+	</head>
+	<body class="is-preload">
+
+		<!-- == Main Content Area ============================================ -->
+		<div id="content" class="custom-fullwidth">
+			<div class="inner">
+				<!-- -- Page Header ------------------- -->
+				<h1 class="extra_h1">Workout Details for {{ selected_year_str }}</h1>
+				<hr class="extra_title_line">
+
+				<!-- -- Flash Messages Section ------------------- -->
+				{% with messages = get_flashed_messages(with_categories=true) %}
+					{% if messages %}
+						<article class="box post post-excerpt">
+						{% for category, message in messages %}
+							<div class="box alert-{{ category }}" style="font-size: 1.3em; border: 1px solid; padding: 16px; margin-bottom: 20px; text-align: center;">
+								{{ message }}
+							</div>
+						{% endfor %}
+						</article>
+					{% endif %}
+				{% endwith %}
+
+				<!-- -- Overall Yearly Summary Section ------------------- -->
+				{% if year_summary_data %}
+					<article class="box post post-excerpt">
+						<header style="margin-bottom: 10px; padding-top: 0px;">
+							<h3 style="margin-bottom: 5px; color: #555;">Overall Summary for {{ selected_year_str }}</h3>
+						</header>
+						<table style="width: 100%; margin-bottom: 20px;">
+							<thead>
+								<tr>
+									<th style="text-align: left; padding: 8px; background-color: #f4f7fb;">Metric</th>
+									<th style="text-align: right; padding: 8px; background-color: #f4f7fb;">Total</th>
+								</tr>
+							</thead>
+							<tbody>
+								<tr>
+									<td style="padding: 8px; border-bottom: 1px solid #eee;">Total Distance:</td>
+									<td style="padding: 8px; border-bottom: 1px solid #eee; text-align: right;">
+										{{ '{:,.0f}'.format(year_summary_data.meters) if year_summary_data.meters is not none else '0' }} m
+									</td>
+								</tr>
+								<tr>
+									<td style="padding: 8px; border-bottom: 1px solid #eee;">Total Duration:</td>
+									<td style="padding: 8px; border-bottom: 1px solid #eee; text-align: right;">
+										{{ year_summary_data.seconds | format_total_seconds_human_readable if year_summary_data.seconds is not none else 'N/A' }}
+									</td>
+								</tr>
+								<tr>
+									<td style="padding: 8px; border-bottom: 1px solid #eee;">Average Split (/500m):</td>
+									<td style="padding: 8px; border-bottom: 1px solid #eee; text-align: right;">
+										{{ year_summary_data.split | format_split_short if year_summary_data.split is not none and year_summary_data.split > 0 else 'N/A' }}
+									</td>
+								</tr>
+								{% if year_summary_data.isoreps and year_summary_data.isoreps > 0 %}
+								<tr>
+									<td style="padding: 8px;">Total IsoReps:</td>
+									<td style="padding: 8px; text-align: right;">
+										{{ '{:,.0f}'.format(year_summary_data.isoreps) }}
+									</td>
+								</tr>
+								{% endif %}
+							</tbody>
+						</table>
+					</article>
+					<hr class="extra_article"> 
+				{% endif %}
+
+				<!-- -- Monthly Summaries in Year Section ------------------- -->
+				{% if monthly_summaries_in_year %}
+					<article class="box post post-excerpt">
+						<header style="margin-bottom: 10px; padding-top: 0px;">
+							<h3 style="margin-bottom: 5px; color: #555;">Monthly Breakdown for {{ selected_year_str }}</h3>
+						</header>
+						<div class="table-wrapper">
+							<table>
+								<thead>
+									<tr>
+										<th>Month (YYYY-MM)</th>
+										<th>Distance</th>
+										<th>Duration</th>
+										<th>Avg. Split</th>
+										<th>Total IsoReps</th>
+										<th>Actions</th>
+									</tr>
+								</thead>
+								<tbody>
+									{% for monthly_summary in monthly_summaries_in_year %}
+									<tr>
+										<td>{{ monthly_summary.year }}-{{ "{:02d}".format(monthly_summary.month) }} ({{ monthly_summary.month_name }})</td>
+										<td>{{ '{:,.0f}'.format(monthly_summary.meters) if monthly_summary.meters > 0 else '-' }} m</td>
+										<td>
+											{{ monthly_summary.seconds | format_total_seconds_human_readable if monthly_summary.seconds > 0 else '-' }}
+										</td>
+										<td>
+											{{ monthly_summary.split | format_split_short if monthly_summary.split > 0 else '-' }}
+										</td>
+										<td>
+											{{ '{:,.0f}'.format(monthly_summary.isoreps) if monthly_summary.isoreps > 0 else '-' }}
+										</td>
+										<td>
+											{% if monthly_summary.has_workouts %}
+											<a href="{{ url_for('workouts_by_month_detail', year_month_str=monthly_summary.year~'-'~'{:02d}'.format(monthly_summary.month)) }}">
+												<i class="fas fa-eye"></i> Details
+											</a>
+											{% else %}
+											<span style="color: #999;">No Workouts</span>
+											{% endif %}
+										</td>
+									</tr>
+									{% endfor %}
+								</tbody>
+							</table>
+						</div>
+					</article>
+					<hr class="extra_article">
+				{% endif %}
+
+				<!-- -- Weekly Summaries in Year Section ------------------- -->
+				{% if weekly_summaries_in_year %}
+					<article class="box post post-excerpt">
+						<header style="margin-bottom: 10px; padding-top: 0px;">
+							<h3 style="margin-bottom: 5px; color: #555;">Weekly Breakdown for {{ selected_year_str }}</h3>
+						</header>
+						<div class="table-wrapper">
+							<table>
+								<thead>
+									<tr>
+										<th>Week (YYYY-Www)</th>
+										<th>Distance</th>
+										<th>Duration</th>
+										<th>Avg. Split</th>
+										<th>Total IsoReps</th>
+										<th>Actions</th>
+									</tr>
+								</thead>
+								<tbody>
+									{% for weekly_summary in weekly_summaries_in_year %}
+									<tr>
+										<td>{{ weekly_summary.year }}-W{{ "{:02d}".format(weekly_summary.week_number) }} <br><small>({{ weekly_summary.week_start_date.strftime('%b %d') }} - {{ weekly_summary.week_end_date_display.strftime('%b %d, %Y') }})</small></td>
+										<td>{{ '{:,.0f}'.format(weekly_summary.meters) if weekly_summary.meters > 0 else '-' }} m</td>
+										<td>
+											{{ weekly_summary.seconds | format_total_seconds_human_readable if weekly_summary.seconds > 0 else '-' }}
+										</td>
+										<td>
+											{{ weekly_summary.split | format_split_short if weekly_summary.split > 0 else '-' }}
+										</td>
+										<td>
+											{{ '{:,.0f}'.format(weekly_summary.isoreps) if weekly_summary.isoreps > 0 else '-' }}
+										</td>
+										<td>
+											{% if weekly_summary.has_workouts %}
+											<a href="{{ url_for('workouts_by_week_detail', year_week_str=weekly_summary.year~'-W'~'{:02d}'.format(weekly_summary.week_number)) }}">
+												<i class="fas fa-eye"></i> Details
+											</a>
+											{% else %}
+											<span style="color: #999;">No Workouts</span>
+											{% endif %}
+										</td>
+									</tr>
+									{% endfor %}
+								</tbody>
+							</table>
+						</div>
+					</article>
+				{% endif %}
+
+				<!-- -- Back Link Section ------------------- -->
+				<div style="text-align: center; margin-top: 30px;">
+					<a href="{{ url_for('yearlysummary') }}" class="button">
+						← Back to Yearly Summary
+					</a>
+				</div>
+			</div>
+		</div>
+		<!-- == Sidebar Inclusion ============================================ -->
+		{% include '_sidebar.html' %}
+
+		<!-- == Scripts ============================================ -->
+		<script src="{{ url_for('static', filename='js/jquery.min.js') }}"></script>
+		<script src="{{ url_for('static', filename='js/browser.min.js') }}"></script>
+		<script src="{{ url_for('static', filename='js/breakpoints.min.js') }}"></script>
+		<script src="{{ url_for('static', filename='js/util.js') }}"></script>
+		<script src="{{ url_for('static', filename='js/main.js') }}"></script>
+	</body>
+</html>

--- a/templates/yearlysummary.html
+++ b/templates/yearlysummary.html
@@ -1,0 +1,125 @@
+<!-- ======================================================== -->
+<!-- = yearlysummary.html - Template for displaying yearly workout summaries -->
+<!-- ======================================================== -->
+<!DOCTYPE HTML>
+<html>
+	<head>
+		<title>{{ page_title | default('Yearly Workout Totals') }}</title>
+		<meta charset="utf-8" />
+		<meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no" />
+		<link rel="icon" href="{{ url_for('static', filename='favicon.ico') }}">
+		<link rel="stylesheet" href="{{ url_for('static', filename='css/main.css') }}" />
+		<link rel="stylesheet" href="{{ url_for('static', filename='css/mystyles.css') }}" />
+	</head>
+	<body class="is-preload">
+
+		<!-- == Main Content Area ============================================ -->
+		<div id="content" class="custom-fullwidth">
+			<div class="inner">
+				<!-- -- Page Header ------------------- -->
+				<h1 class="extra_h1">{{ page_title | default('Yearly Summary') }}</h1>
+				<hr class="extra_title_line">
+
+				<!-- -- Flash Messages Section ------------------- -->
+				{% with messages = get_flashed_messages(with_categories=true) %}
+					{% if messages %}
+						<article class="box post post-excerpt">
+						{% for category, message in messages %}
+							<div class="box alert-{{ category }}" style="font-size: 1.3em; border: 1px solid; padding: 16px; margin-bottom: 20px; text-align: center;">
+								{{ message }}
+							</div>
+						{% endfor %}
+						</article>
+					{% endif %}
+				{% endwith %}
+					
+				<!-- -- Yearly Totals Table Section ------------------- -->
+				{% if yearlysummary_display_data %}
+					<article class="box post post-excerpt">
+						<div class="table-wrapper">
+							<table>
+								<thead>
+									<tr>
+										<th>Year</th>
+										<th>Distance</th>
+										<th>Duration</th>
+										<th>Avg. Split</th>
+										<th>Total IsoReps</th>
+										<th>Actions</th>
+									</tr>
+								</thead>
+								<tbody>
+									{% for summary in yearlysummary_display_data %}
+									<tr>
+										<td>{{ summary.year }}</td>
+										<td>{{ '{:,.0f}'.format(summary.meters) if summary.meters is not none else '0' }} m</td>
+										<td>
+											{{ summary.seconds | format_total_seconds_human_readable if summary.seconds is not none else 'N/A' }}
+										</td>
+										<td>
+											{{ summary.split | format_split_short if summary.split is not none and summary.split > 0 else 'N/A' }}
+										</td>
+										<td>
+											{{ '{:,.0f}'.format(summary.isoreps) if summary.isoreps is not none else '0' }}
+										</td>
+										<td>
+											<a href="{{ url_for('workouts_by_year_detail', year_param=summary.year) }}">
+												<i class="fas fa-eye"></i> Details
+											</a>
+										</td>
+									</tr>
+									{% endfor %}
+								</tbody>
+							</table>
+						</div>
+					</article>
+				{% else %}							
+					<article class="box post post-excerpt">
+						<div class="box alert-info" style="font-size: 1.3em; border: 1px solid; padding: 16px; margin-bottom: 20px; text-align: center;">
+							No yearly totals found.
+						</div>
+					</article>
+				{% endif %}
+
+				<!-- -- Pagination Section ------------------- -->
+				{% if yearlysummary_pagination and yearlysummary_pagination.pages > 1 %}
+					<div class="pagination">
+						{% if yearlysummary_pagination.has_prev %}
+							<a href="{{ url_for('yearlysummary_paginated', page_num=yearlysummary_pagination.prev_num) }}"
+							   class="button previous">Previous Page</a>
+						{% else %}
+							<span class="button previous disabled" aria-disabled="true">Previous Page</span>
+						{% endif %}
+						
+						<div class="pages">
+							{% for page in yearlysummary_pagination.iter_pages(left_edge=1, right_edge=1, left_current=2, right_current=2) %}
+								{% if page %}
+									<a href="{{ url_for('yearlysummary_paginated', page_num=page) }}"
+									   class="{% if page == yearlysummary_pagination.page %}active{% endif %}">{{ page }}</a>
+								{% else %}
+									<span>…</span>
+								{% endif %}
+							{% endfor %}
+						</div>
+						
+						{% if yearlysummary_pagination.has_next %}
+							<a href="{{ url_for('yearlysummary_paginated', page_num=yearlysummary_pagination.next_num) }}"
+							   class="button next">Next Page</a>
+						{% else %}
+							<span class="button next disabled" aria-disabled="true">Next Page</span>
+						{% endif %}
+					</div>
+				{% endif %}
+			</div>
+		</div>
+		<!-- == Sidebar Inclusion ============================================ -->
+		{% include '_sidebar.html' %}
+
+		<!-- == Scripts ============================================ -->
+		<script src="{{ url_for('static', filename='js/jquery.min.js') }}"></script>
+		<script src="{{ url_for('static', filename='js/browser.min.js') }}"></script>
+		<script src="{{ url_for('static', filename='js/breakpoints.min.js') }}"></script>
+		<script src="{{ url_for('static', filename='js/util.js') }}"></script>
+		<script src="{{ url_for('static', filename='js/main.js') }}"></script>
+	</body>
+</html>

--- a/utils.py
+++ b/utils.py
@@ -5,6 +5,36 @@ from sqlalchemy import text
 # Removed: from datetime import datetime, timedelta (not used by current functions)
 from decimal import Decimal # <--- ADD THIS LINE TO IMPORT DECIMAL
 
+def parse_duration_to_seconds(time_str):
+    """
+    Parses a time string (H:M:S.ms, M:S.ms, S.ms) into total seconds.
+    Returns None if parsing fails.
+    """
+    if not time_str:
+        return None
+    
+    parts = time_str.split(':')
+    total_seconds = 0
+    
+    try:
+        if len(parts) == 3: # H:M:S.ms
+            h = int(parts[0])
+            m = int(parts[1])
+            s_ms_part = float(parts[2])
+            total_seconds = h * 3600 + m * 60 + s_ms_part
+        elif len(parts) == 2: # M:S.ms
+            m = int(parts[0])
+            s_ms_part = float(parts[1])
+            total_seconds = m * 60 + s_ms_part
+        elif len(parts) == 1: # S.ms or S
+            s_ms_part = float(parts[0])
+            total_seconds = s_ms_part
+        else:
+            return None
+        return total_seconds
+    except ValueError:
+        return None
+        
 def format_duration_ms(total_seconds):
     if total_seconds is None or not isinstance(total_seconds, (int, float, Decimal)) or total_seconds < 0: # Added Decimal here too for consistency
         return "00:00.00"

--- a/utils.py
+++ b/utils.py
@@ -126,3 +126,34 @@ def sidebar_stats_processor():
         }
     
     return dict(sidebar_stats=stats) # Make stats available to templates
+
+# --------------------------------------------------------
+# - Custom Pagination Class
+#---------------------------------------------------------
+# Provides pagination logic for views not using Flask-SQLAlchemy's paginate().
+class CustomPagination:
+    # -- Initialization Method -------------------
+    def __init__(self, page, per_page, total_count, items):
+        self.page = page # Current page number
+        self.per_page = per_page # Items per page
+        self.total = total_count # Total number of items
+        self.pages = (total_count + per_page - 1) // per_page if total_count > 0 else 1 # Total number of pages
+        self.has_prev = self.page > 1 # True if there's a previous page
+        self.has_next = self.page < self.pages # True if there's a next page
+        self.prev_num = self.page - 1 if self.has_prev else None # Previous page number
+        self.next_num = self.page + 1 if self.has_next else None # Next page number
+        self.items = items # The actual items for the current page
+
+    # -- Page Iterator Method -------------------
+    # Generates page numbers for pagination links, including ellipses.
+    def iter_pages(self, left_edge=2, right_edge=2, left_current=2, right_current=3):
+        last_page = 0
+        for num in range(1, self.pages + 1):
+            # Determine if the page number should be displayed
+            if num <= left_edge or \
+               (num > self.page - left_current - 1 and num < self.page + right_current) or \
+               num > self.pages - right_edge:
+                if last_page + 1 != num: # If there's a gap, yield None for ellipsis
+                    yield None
+                yield num # Yield the page number
+                last_page = num

--- a/utils.py
+++ b/utils.py
@@ -1,15 +1,9 @@
-# utils.py
 from flask import current_app
 from models import db
 from sqlalchemy import text
-# Removed: from datetime import datetime, timedelta (not used by current functions)
-from decimal import Decimal # <--- ADD THIS LINE TO IMPORT DECIMAL
+from decimal import Decimal
 
 def parse_duration_to_seconds(time_str):
-    """
-    Parses a time string (H:M:S.ms, M:S.ms, S.ms) into total seconds.
-    Returns None if parsing fails.
-    """
     if not time_str:
         return None
     
@@ -17,16 +11,16 @@ def parse_duration_to_seconds(time_str):
     total_seconds = 0
     
     try:
-        if len(parts) == 3: # H:M:S.ms
+        if len(parts) == 3:
             h = int(parts[0])
             m = int(parts[1])
             s_ms_part = float(parts[2])
             total_seconds = h * 3600 + m * 60 + s_ms_part
-        elif len(parts) == 2: # M:S.ms
+        elif len(parts) == 2:
             m = int(parts[0])
             s_ms_part = float(parts[1])
             total_seconds = m * 60 + s_ms_part
-        elif len(parts) == 1: # S.ms or S
+        elif len(parts) == 1:
             s_ms_part = float(parts[0])
             total_seconds = s_ms_part
         else:
@@ -36,9 +30,9 @@ def parse_duration_to_seconds(time_str):
         return None
         
 def format_duration_ms(total_seconds):
-    if total_seconds is None or not isinstance(total_seconds, (int, float, Decimal)) or total_seconds < 0: # Added Decimal here too for consistency
+    if total_seconds is None or not isinstance(total_seconds, (int, float, Decimal)) or total_seconds < 0:
         return "00:00.00"
-    total_seconds_float = float(total_seconds) # Convert to float for calculations
+    total_seconds_float = float(total_seconds)
     minutes = int(total_seconds_float // 60)
     remaining_seconds_component = total_seconds_float % 60
     seconds = int(remaining_seconds_component)
@@ -46,9 +40,6 @@ def format_duration_ms(total_seconds):
     return f"{minutes:02d}:{seconds:02d}.{centiseconds:02d}"
 
 def sidebar_stats_processor():
-    """
-    Fetches various rowing statistics from materialized views for the sidebar.
-    """
     stats = {}
     try:
         with db.engine.connect() as connection:
@@ -59,7 +50,7 @@ def sidebar_stats_processor():
                     'seconds': float(overall_totals_result.total_seconds_rowed) if overall_totals_result.total_seconds_rowed is not None else 0,
                     'split': float(overall_totals_result.average_split_seconds_per_500m) if overall_totals_result.average_split_seconds_per_500m is not None else 0
                 }
-            else: # Handle case where mv_sum_totals might be empty
+            else:
                 stats['overall_totals'] = {'meters': 0, 'seconds': 0, 'split': 0}
 
 
@@ -73,11 +64,10 @@ def sidebar_stats_processor():
 
 
 def format_total_seconds_human_readable(total_seconds):
-    # The isinstance check now includes Decimal
     if total_seconds is None or not isinstance(total_seconds, (int, float, Decimal)) or total_seconds < 0:
         return "N/A"
     
-    total_seconds = float(total_seconds) # Convert to float for consistent math operations
+    total_seconds = float(total_seconds)
 
     days = int(total_seconds // (24 * 3600))
     remaining_seconds_after_days = total_seconds % (24 * 3600)
@@ -89,36 +79,28 @@ def format_total_seconds_human_readable(total_seconds):
     parts = []
     if days > 0:
         parts.append(f"{days}d")
-    # Show hours if days are shown, or if hours > 0 and no days
     if hours > 0: 
         parts.append(f"{hours:02d}h" if days > 0 else f"{hours}h")
-    elif days > 0: # If days > 0 but hours is 0, still show 00h
+    elif days > 0:
          parts.append("00h")
     
-    # Always show minutes and seconds if there was any duration or if we want to show 00m:00s for 0 total_seconds
-    if total_seconds >= 0: # Show 00m:00s for 0 seconds
+    if total_seconds >= 0:
          parts.append(f"{minutes:02d}m")
          parts.append(f"{seconds:02d}s")
     
-    if not parts: # Should not happen if total_seconds >= 0
+    if not parts:
         return "00m:00s"
         
     return ":".join(parts)
 
 def format_split_short(total_split_seconds_raw):
-    # The isinstance check now includes Decimal
     if total_split_seconds_raw is None or not isinstance(total_split_seconds_raw, (int, float, Decimal)) or total_split_seconds_raw <= 0:
         return "N/A"
     
-    total_split_seconds_raw = float(total_split_seconds_raw) # Convert to float for consistent math operations
+    total_split_seconds_raw = float(total_split_seconds_raw)
     minutes = int(total_split_seconds_raw // 60)
     remaining_seconds_float = total_split_seconds_raw % 60
     
-    # To get "ss.s" (e.g., 27.9 from 27.979...)
-    # Multiply by 10 (e.g., 27.979 -> 279.79)
-    # Truncate to integer (279)
-    # Extract integer seconds (279 // 10 = 27)
-    # Extract single millisecond digit (279 % 10 = 9)
     seconds_and_ms_combined_truncated = int(remaining_seconds_float * 10) 
     
     seconds_part = int(seconds_and_ms_combined_truncated // 10) 

--- a/views/dailysummary.py
+++ b/views/dailysummary.py
@@ -1,31 +1,37 @@
-# views/dailysummary.py
+# ========================================================
+# = dailysummary.py - View for displaying paginated daily workout summaries
+# ========================================================
 from flask import render_template, redirect, url_for, current_app
 from sqlalchemy import text # Import text for raw SQL execution
 from models import db # Assuming db is initialized and available
 
+# --------------------------------------------------------
+# - Daily Summary View Function
+#---------------------------------------------------------
+# Displays paginated daily workout summaries from the mv_day_totals materialized view.
 def dailysummary(page_num=1):
-    per_page_value = current_app.config.get('PER_PAGE', 10) # Get PER_PAGE from app config
+    # == Pagination Configuration ============================================
+    per_page_value = current_app.config.get('PER_PAGE', 10) # Get items per page from app config
 
-    # Query the materialized view directly
-    # Note: Paginate from a raw SQL query can be tricky with SQLAlchemy's ORM paginate.
-    # We'll use a subquery approach with ORDER BY and LIMIT/OFFSET for pagination.
-    
-    # First, get the total count for pagination
-    count_result = db.session.execute(text("SELECT COUNT(*) FROM mv_day_totals")).scalar()
-    total_pages = (count_result + per_page_value - 1) // per_page_value if count_result > 0 else 1
+    # == Query Total Count for Pagination ============================================
+    # Get the total number of daily summary records for pagination logic.
+    count_result = db.session.execute(text("SELECT COUNT(*) FROM mv_day_totals")).scalar() # Total records in mv_day_totals
+    total_pages = (count_result + per_page_value - 1) // per_page_value if count_result > 0 else 1 # Calculate total pages
 
-    # Adjust page_num if it's out of bounds (e.g., if page_num is too high)
+    # == Page Number Validation and Redirection ============================================
+    # Ensure page_num is within valid bounds.
     if page_num < 1:
-        page_num = 1
-    elif page_num > total_pages and total_pages > 0:
+        page_num = 1 # Default to page 1 if page_num is less than 1
+    elif page_num > total_pages and total_pages > 0: # If requested page is beyond the last page with data
         return redirect(url_for('dailysummary_paginated', page_num=total_pages))
-    elif page_num > total_pages and total_pages == 0:
+    elif page_num > total_pages and total_pages == 0: # If no data, redirect to page 1
         return redirect(url_for('dailysummary_paginated', page_num=1))
 
-    # Calculate OFFSET
-    offset = (page_num - 1) * per_page_value
+    # == Calculate Offset for SQL Query ============================================
+    offset = (page_num - 1) * per_page_value # Calculate the starting point for records on the current page
 
-    # Query data for the current page
+    # == Query Data for Current Page ============================================
+    # Fetch daily summary data for the current page using LIMIT and OFFSET.
     dailysummary_raw_results = db.session.execute(text(f"""
         SELECT
             day_date,
@@ -37,8 +43,10 @@ def dailysummary(page_num=1):
         ORDER BY
             day_date DESC
         LIMIT :limit OFFSET :offset
-    """), {'limit': per_page_value, 'offset': offset}).fetchall()
+    """), {'limit': per_page_value, 'offset': offset}).fetchall() # Execute query with parameters
 
+    # == Prepare Data for Template ============================================
+    # Convert raw SQL results into a list of dictionaries for easier template access.
     dailysummary_display_data = []
     for row in dailysummary_raw_results:
         dailysummary_display_data.append({
@@ -48,42 +56,50 @@ def dailysummary(page_num=1):
             'split': float(row.split)
         })
 
-    # Manually construct a pagination-like object for the template
-    # Flask-SQLAlchemy's paginate object has useful attributes, so we mimic them.
+    # == Custom Pagination Object ============================================
+    # Create a custom pagination object to mimic Flask-SQLAlchemy's pagination behavior for the template.
+    # -- CustomPagination Class Definition -------------------
     class CustomPagination:
+        # -- Initialization Method -------------------
         def __init__(self, page, per_page, total_count, items):
-            self.page = page
-            self.per_page = per_page
-            self.total = total_count
-            self.pages = (total_count + per_page - 1) // per_page if total_count > 0 else 1
-            self.has_prev = self.page > 1
-            self.has_next = self.page < self.pages
-            self.prev_num = self.page - 1 if self.has_prev else None
-            self.next_num = self.page + 1 if self.has_next else None
-            self.items = items # Not strictly used for iteration in template, but good practice
+            self.page = page # Current page number
+            self.per_page = per_page # Items per page
+            self.total = total_count # Total number of items
+            self.pages = (total_count + per_page - 1) // per_page if total_count > 0 else 1 # Total number of pages
+            self.has_prev = self.page > 1 # True if there's a previous page
+            self.has_next = self.page < self.pages # True if there's a next page
+            self.prev_num = self.page - 1 if self.has_prev else None # Previous page number
+            self.next_num = self.page + 1 if self.has_next else None # Next page number
+            self.items = items # The actual items for the current page (not used for iteration in template but good for consistency)
 
+        # -- Page Iterator Method -------------------
+        # Generates page numbers for pagination links, including ellipses.
         def iter_pages(self, left_edge=2, right_edge=2, left_current=2, right_current=3):
-            # This is a simplified version of Flask-SQLAlchemy's iter_pages
-            # You might want to copy the full logic if you need exact matching.
             last_page = 0
             for num in range(1, self.pages + 1):
+                # Determine if the page number should be displayed
                 if num <= left_edge or \
                    (num > self.page - left_current - 1 and num < self.page + right_current) or \
                    num > self.pages - right_edge:
-                    if last_page + 1 != num:
-                        yield None # Ellipsis
-                    yield num
+                    if last_page + 1 != num: # If there's a gap, yield None for ellipsis
+                        yield None
+                    yield num # Yield the page number
                     last_page = num
 
+    # -- Instantiate Custom Pagination Object -------------------
     dailysummary_pagination = CustomPagination(page_num, per_page_value, count_result, dailysummary_display_data)
 
-
+    # == Render Template ============================================
     return render_template(
         'dailysummary.html',
-        dailysummary_pagination=dailysummary_pagination,
-        dailysummary_display_data=dailysummary_display_data
+        dailysummary_pagination=dailysummary_pagination, # Pass pagination object to template
+        dailysummary_display_data=dailysummary_display_data # Pass display data to template
     )
 
+# --------------------------------------------------------
+# - Route Registration
+#---------------------------------------------------------
+# Registers the daily summary view routes with the Flask application.
 def register_routes(app):
-    app.add_url_rule('/dailysummary/', endpoint='dailysummary', view_func=lambda: dailysummary(1), methods=['GET'])
-    app.add_url_rule('/dailysummary/page/<int:page_num>', endpoint='dailysummary_paginated', view_func=dailysummary, methods=['GET'])
+    app.add_url_rule('/dailysummary/', endpoint='dailysummary', view_func=lambda: dailysummary(1), methods=['GET']) # Route for the first page
+    app.add_url_rule('/dailysummary/page/<int:page_num>', endpoint='dailysummary_paginated', view_func=dailysummary, methods=['GET']) # Route for subsequent pages

--- a/views/dailysummary.py
+++ b/views/dailysummary.py
@@ -4,6 +4,7 @@
 from flask import render_template, redirect, url_for, current_app
 from sqlalchemy import text # Import text for raw SQL execution
 from models import db # Assuming db is initialized and available
+from utils import CustomPagination # Import CustomPagination from utils
 
 # --------------------------------------------------------
 # - Daily Summary View Function
@@ -37,7 +38,8 @@ def dailysummary(page_num=1):
             day_date,
             total_meters_rowed,
             total_seconds_rowed,
-            average_split_seconds_per_500m AS split
+            average_split_seconds_per_500m AS split,
+            total_isoreps_sum
         FROM
             mv_day_totals
         ORDER BY
@@ -51,40 +53,15 @@ def dailysummary(page_num=1):
     for row in dailysummary_raw_results:
         dailysummary_display_data.append({
             'day_date': row.day_date,
-            'meters': float(row.total_meters_rowed),
-            'seconds': float(row.total_seconds_rowed),
-            'split': float(row.split)
+            'meters': float(row.total_meters_rowed) if row.total_meters_rowed is not None else 0,
+            'seconds': float(row.total_seconds_rowed) if row.total_seconds_rowed is not None else 0,
+            'split': float(row.split) if row.split is not None else 0,
+            'isoreps': float(row.total_isoreps_sum) if row.total_isoreps_sum is not None else 0
         })
 
     # == Custom Pagination Object ============================================
-    # Create a custom pagination object to mimic Flask-SQLAlchemy's pagination behavior for the template.
-    # -- CustomPagination Class Definition -------------------
-    class CustomPagination:
-        # -- Initialization Method -------------------
-        def __init__(self, page, per_page, total_count, items):
-            self.page = page # Current page number
-            self.per_page = per_page # Items per page
-            self.total = total_count # Total number of items
-            self.pages = (total_count + per_page - 1) // per_page if total_count > 0 else 1 # Total number of pages
-            self.has_prev = self.page > 1 # True if there's a previous page
-            self.has_next = self.page < self.pages # True if there's a next page
-            self.prev_num = self.page - 1 if self.has_prev else None # Previous page number
-            self.next_num = self.page + 1 if self.has_next else None # Next page number
-            self.items = items # The actual items for the current page (not used for iteration in template but good for consistency)
-
-        # -- Page Iterator Method -------------------
-        # Generates page numbers for pagination links, including ellipses.
-        def iter_pages(self, left_edge=2, right_edge=2, left_current=2, right_current=3):
-            last_page = 0
-            for num in range(1, self.pages + 1):
-                # Determine if the page number should be displayed
-                if num <= left_edge or \
-                   (num > self.page - left_current - 1 and num < self.page + right_current) or \
-                   num > self.pages - right_edge:
-                    if last_page + 1 != num: # If there's a gap, yield None for ellipsis
-                        yield None
-                    yield num # Yield the page number
-                    last_page = num
+    # The local CustomPagination class definition that was previously here is removed.
+    # We now use the CustomPagination class imported from utils.py.
 
     # -- Instantiate Custom Pagination Object -------------------
     dailysummary_pagination = CustomPagination(page_num, per_page_value, count_result, dailysummary_display_data)

--- a/views/details.py
+++ b/views/details.py
@@ -1,59 +1,79 @@
-# views/details.py
+# ========================================================
+# = details.py - View for displaying detailed workout information
+# ========================================================
 from flask import render_template
 from sqlalchemy.orm import joinedload, selectinload
 from sqlalchemy import distinct
-# Import db ALONG WITH your models
 from models import db, Workout, WorkoutSample, HeartRateSample, MetricDescriptor
 
+# --------------------------------------------------------
+# - Workout Details View Function
+#---------------------------------------------------------
+# Displays detailed information for a specific workout, including samples.
 def details(workout_id):
+    # == Fetch Main Workout Data ============================================
+    # Retrieve the workout by ID, preloading related equipment type and HR zones
+    # get_or_404 will automatically return a 404 error if the workout_id is not found.
     workout = Workout.query.options(
-        joinedload(Workout.equipment_type_ref),
-        joinedload(Workout.workout_hr_zones)
+        joinedload(Workout.equipment_type_ref), # Eager load equipment type
+        joinedload(Workout.workout_hr_zones) # Eager load heart rate zones
     ).get_or_404(workout_id)
 
-    # Now 'db' will be defined
+    # == Fetch Metric Descriptors for this Workout ============================================
+    # -- Get IDs of MetricDescriptors that have samples for this workout -------------------
     metric_descriptor_ids_with_samples = db.session.query(
-        distinct(WorkoutSample.metric_descriptor_id)
+        distinct(WorkoutSample.metric_descriptor_id) # Select unique metric_descriptor_ids
     ).filter(
-        WorkoutSample.workout_id == workout_id
-    ).all()
+        WorkoutSample.workout_id == workout_id # Filter by the current workout_id
+    ).all() # Execute query and get all results
     
+    # -- Extract actual IDs from the query result (list of tuples) -------------------
     actual_metric_descriptor_ids = [md_id[0] for md_id in metric_descriptor_ids_with_samples if md_id[0] is not None]
 
+    # -- Fetch MetricDescriptor objects based on the IDs found -------------------
     workout_metric_descriptors_list = []
-    if actual_metric_descriptor_ids:
+    if actual_metric_descriptor_ids: # If there are any metric descriptors with samples
         workout_metric_descriptors_list = MetricDescriptor.query.filter(
-            MetricDescriptor.metric_descriptor_id.in_(actual_metric_descriptor_ids)
-        ).order_by(MetricDescriptor.metric_name).all()
+            MetricDescriptor.metric_descriptor_id.in_(actual_metric_descriptor_ids) # Filter by the list of IDs
+        ).order_by(MetricDescriptor.metric_name).all() # Order by name for consistent display
 
+    # == Fetch Workout Samples (Metrics) ============================================
+    # -- Base query for all workout samples, ordered by time offset -------------------
     all_workout_samples_query = WorkoutSample.query.options(
-        selectinload(WorkoutSample.metric_descriptor_ref) 
+        selectinload(WorkoutSample.metric_descriptor_ref) # Eager load related metric descriptor for each sample
     ).filter_by(workout_id=workout_id).order_by(WorkoutSample.time_offset_seconds.asc())
     
-    total_workout_samples = all_workout_samples_query.count()
+    total_workout_samples = all_workout_samples_query.count() # Get total count of samples
     
-    first_10_workout_samples = all_workout_samples_query.limit(10).all()
+    # -- Logic to display first 10, last 10, and ellipsis if more than 20 samples -------------------
+    first_10_workout_samples = all_workout_samples_query.limit(10).all() # Get the first 10 samples
     last_10_workout_samples = []
     workout_samples_ellipsis_needed = False
-    if total_workout_samples > 10:
-        if total_workout_samples <= 20:
+    if total_workout_samples > 10: # If more than 10 samples in total
+        if total_workout_samples <= 20: # If 11-20 samples, show all remaining
             last_10_workout_samples = all_workout_samples_query.offset(10).limit(10).all()
-        else:
+        else: # If more than 20 samples, show ellipsis and last 10
             workout_samples_ellipsis_needed = True
             last_10_workout_samples = all_workout_samples_query.offset(total_workout_samples - 10).limit(10).all()
 
+    # == Fetch Heart Rate Samples ============================================
+    # -- Base query for all heart rate samples, ordered by time offset -------------------
     all_hr_samples_query = HeartRateSample.query.filter_by(workout_id=workout_id).order_by(HeartRateSample.time_offset_seconds.asc())
-    total_hr_samples = all_hr_samples_query.count()
-    first_10_hr_samples = all_hr_samples_query.limit(10).all()
+    total_hr_samples = all_hr_samples_query.count() # Get total count of HR samples
+    
+    # -- Logic to display first 10, last 10, and ellipsis if more than 20 HR samples -------------------
+    first_10_hr_samples = all_hr_samples_query.limit(10).all() # Get the first 10 HR samples
     last_10_hr_samples = []
     hr_samples_ellipsis_needed = False
-    if total_hr_samples > 10:
-        if total_hr_samples <= 20:
+    if total_hr_samples > 10: # If more than 10 HR samples in total
+        if total_hr_samples <= 20: # If 11-20 HR samples, show all remaining
             last_10_hr_samples = all_hr_samples_query.offset(10).limit(10).all()
-        else:
+        else: # If more than 20 HR samples, show ellipsis and last 10
             hr_samples_ellipsis_needed = True
             last_10_hr_samples = all_hr_samples_query.offset(total_hr_samples - 10).limit(10).all()
             
+    # == Render Template ============================================
+    # Pass all fetched and processed data to the details.html template
     return render_template(
         'details.html',
         workout=workout,
@@ -68,5 +88,9 @@ def details(workout_id):
         hr_samples_ellipsis_needed=hr_samples_ellipsis_needed
     )
 
+# --------------------------------------------------------
+# - Route Registration
+#---------------------------------------------------------
+# Registers the workout details view route with the Flask application
 def register_routes(app):
     app.add_url_rule('/details/<int:workout_id>', endpoint='details', view_func=details, methods=['GET'])

--- a/views/home.py
+++ b/views/home.py
@@ -1,36 +1,39 @@
-# views/home.py
+# ========================================================
+# = home.py - View for the home page
+# ========================================================
 from flask import render_template
-# Removed: from sqlalchemy.orm import joinedload (no longer strictly needed here for summary data)
 from models import Workout
-# Removed: from utils import format_duration_ms (no longer used in this file, template uses it)
 
-# You might want a new utility function for formatting total_seconds into hh:mm:ss or d:hh:mm
-# e.g., from utils import format_seconds_to_readable_time
-
+# --------------------------------------------------------
+# - Home View Function
+#---------------------------------------------------------
+# Displays the home page with the latest five workouts.
 def home():
+    # == Query Latest Workouts ============================================
+    # Fetch the latest five workouts, ordered by date and then ID for consistency
     latest_five_workouts = Workout.query.order_by(
-        Workout.workout_date.desc(),
-        Workout.workout_id.desc()
-    ).limit(5).all()
+        Workout.workout_date.desc(), # Order by workout date descending
+        Workout.workout_id.desc() # Then by workout ID descending
+    ).limit(5).all() # Limit to 5 results
 
-    # Simplified: workouts_display_data will now just be a list of Workout objects
-    # The templates (index.html) will handle formatting directly using filters.
-    # We still pass it as 'workouts_display_data' for consistency if the template
-    # expects 'item_data.workout_obj' inside a loop.
-    # Alternatively, we could just pass 'latest_five_workouts' directly and adjust the template.
-    # For minimal change to the template, we'll wrap it.
-    
+    # == Prepare Data for Template ============================================
+    # The template (index.html) will directly use workout objects and Jinja filters for formatting.
+    # Data is wrapped to maintain consistency with how templates might expect 'item_data.workout_obj'.
     workouts_display_data = []
-    for workout_item in latest_five_workouts:
+    for workout_item in latest_five_workouts: # Iterate through the fetched workouts
         workouts_display_data.append({
-            'workout_obj': workout_item,
-            'name': workout_item.workout_name # This was already used by the template
-            # The 'summary' dictionary is removed as templates format directly
+            'workout_obj': workout_item, # Pass the raw workout object
+            'name': workout_item.workout_name # Include workout name for direct access in template
         })
 
+    # == Render Template ============================================
     return render_template('index.html',
-        workouts_display_data=workouts_display_data
+        workouts_display_data=workouts_display_data # Pass the prepared list of workouts
     )
 
+# --------------------------------------------------------
+# - Route Registration
+#---------------------------------------------------------
+# Registers the home page route with the Flask application
 def register_routes(app):
-    app.add_url_rule('/', view_func=home, methods=['GET'])
+    app.add_url_rule('/', view_func=home, methods=['GET']) # Root URL for the application

--- a/views/monthlysummary.py
+++ b/views/monthlysummary.py
@@ -1,0 +1,79 @@
+# ========================================================
+# = monthlysummary.py - View for displaying paginated monthly workout summaries
+# ========================================================
+from flask import render_template, redirect, url_for, current_app
+from sqlalchemy import text
+from models import db 
+from utils import CustomPagination 
+from datetime import datetime
+
+# --------------------------------------------------------
+# - Monthly Summary View Function
+#---------------------------------------------------------
+# Displays paginated monthly workout summaries from the mv_month_totals materialized view.
+def monthlysummary(page_num=1):
+    # == Pagination Configuration ============================================
+    per_page_value = current_app.config.get('PER_PAGE', 10) 
+
+    # == Query Total Count for Pagination ============================================
+    count_result = db.session.execute(text("SELECT COUNT(*) FROM mv_month_totals")).scalar()
+    total_pages = (count_result + per_page_value - 1) // per_page_value if count_result > 0 else 1
+
+    # == Page Number Validation and Redirection ============================================
+    if page_num < 1:
+        page_num = 1
+    elif page_num > total_pages and total_pages > 0:
+        return redirect(url_for('monthlysummary_paginated', page_num=total_pages))
+    elif page_num > total_pages and total_pages == 0: 
+        return redirect(url_for('monthlysummary_paginated', page_num=1))
+
+    # == Calculate Offset for SQL Query ============================================
+    offset = (page_num - 1) * per_page_value
+
+    # == Query Data for Current Page ============================================
+    monthlysummary_raw_results = db.session.execute(text(f"""
+        SELECT
+            year,
+            month,
+            total_meters_rowed,
+            total_seconds_rowed,
+            average_split_seconds_per_500m AS split,
+            total_isoreps_sum
+        FROM
+            mv_month_totals
+        ORDER BY
+            year DESC, month DESC
+        LIMIT :limit OFFSET :offset
+    """), {'limit': per_page_value, 'offset': offset}).fetchall()
+
+    # == Prepare Data for Template ============================================
+    monthlysummary_display_data = []
+    for row in monthlysummary_raw_results:
+        monthlysummary_display_data.append({
+            'year': int(row.year),
+            'month': int(row.month),
+            'month_name': datetime(int(row.year), int(row.month), 1).strftime('%B'),
+            'meters': float(row.total_meters_rowed) if row.total_meters_rowed is not None else 0,
+            'seconds': float(row.total_seconds_rowed) if row.total_seconds_rowed is not None else 0,
+            'split': float(row.split) if row.split is not None else 0,
+            'isoreps': float(row.total_isoreps_sum) if row.total_isoreps_sum is not None else 0
+        })
+
+    # == Custom Pagination Object ============================================
+    monthlysummary_pagination = CustomPagination(page_num, per_page_value, count_result, monthlysummary_display_data)
+
+    # == Render Template ============================================
+    return render_template(
+        'monthlysummary.html',
+        monthlysummary_pagination=monthlysummary_pagination,
+        monthlysummary_display_data=monthlysummary_display_data,
+        page_title="Monthly Workout Summaries"
+    )
+
+# --------------------------------------------------------
+# - Route Registration
+#---------------------------------------------------------
+# Registers the monthly summary view routes with the Flask application.
+def register_routes(app):
+    app.add_url_rule('/monthlysummary/', endpoint='monthlysummary', view_func=lambda: monthlysummary(1), methods=['GET'])
+    app.add_url_rule('/monthlysummary/page/<int:page_num>', endpoint='monthlysummary_paginated', view_func=monthlysummary, methods=['GET'])

--- a/views/submit_json_workout.py
+++ b/views/submit_json_workout.py
@@ -1,38 +1,48 @@
-# views/submit_json_workout.py
+# ========================================================
+# = submit_json_workout.py - View for submitting workout data via JSON
+# ========================================================
 import json
 from flask import request, redirect, url_for, flash, current_app
 from datetime import datetime
-from sqlalchemy.exc import IntegrityError # Keep for other integrity errors
+from sqlalchemy.exc import IntegrityError
 from models import db, EquipmentType, Workout, MetricDescriptor, WorkoutSample, HeartRateSample, WorkoutHRZone
-from utils import format_duration_ms
+from utils import format_duration_ms # Retained as it might be used for debugging or future display logic, though not directly in current processing
 
+# --------------------------------------------------------
+# - JSON Workout Submission View Function
+#---------------------------------------------------------
 def submit_json_workout():
-    raw_json_data = request.form.get('jsonData')
-    workout_notes = request.form.get('jsonNotes') # <--- GET NOTES FROM THE FORM
+    # == Form Data Retrieval ============================================
+    raw_json_data = request.form.get('jsonData') # Get raw JSON string from form
+    workout_notes = request.form.get('jsonNotes') # Get workout notes from form
 
+    # == Initial JSON Data Validation ============================================
     if not raw_json_data:
         flash('No JSON data provided.', 'danger')
         return redirect(url_for('home'))
 
     try:
-        json_data = json.loads(raw_json_data)
+        json_data = json.loads(raw_json_data) # Parse JSON string
     except json.JSONDecodeError:
         flash('Invalid JSON format.', 'danger')
         return redirect(url_for('home'))
 
     try:
-        workout_main_container = json_data.get('data', {})
+        # == Main Workout Data Extraction ============================================
+        workout_main_container = json_data.get('data', {}) # Main data object in JSON
         if not workout_main_container:
             flash('Main "data" object is missing or empty in the submitted JSON.', 'danger')
             return redirect(url_for('home'))
 
-        equipment_name = "SKILLROW"
+        # == Equipment Type Handling ============================================
+        equipment_name = "SKILLROW" # Default equipment for JSON submissions
         equipment_type = EquipmentType.query.filter_by(name=equipment_name).first()
-        if not equipment_type:
+        if not equipment_type: # Create if not exists
             equipment_type = EquipmentType(name=equipment_name)
             db.session.add(equipment_type)
-            db.session.flush()
+            db.session.flush() # Ensure ID is available
 
+        # == Cardio Log ID and Existing Workout Check ============================================
         cardio_log_id = workout_main_container.get('cardioLogId')
         if not cardio_log_id:
             flash('Cardio Log ID is missing.', 'danger')
@@ -41,83 +51,85 @@ def submit_json_workout():
         existing_workout = Workout.query.filter_by(cardio_log_id=cardio_log_id).first()
         if existing_workout:
             flash(f'Workout with Cardio Log ID {cardio_log_id} already exists.', 'warning')
-            # If workout exists, you might want to update its notes if new notes are provided
-            # For now, it just redirects.
+            # Future: Consider updating notes if new notes are provided for an existing workout
             return redirect(url_for('details', workout_id=existing_workout.workout_id))
 
+        # == Workout Date Parsing ============================================
         workout_date_str = workout_main_container.get('date')
         try:
-            workout_date_obj = datetime.strptime(workout_date_str, '%d/%m/%Y').date()
+            workout_date_obj = datetime.strptime(workout_date_str, '%d/%m/%Y').date() # Expected format DD/MM/YYYY
         except (ValueError, TypeError):
             flash(f'Invalid date format: {workout_date_str}. Expected DD/MM/YYYY.', 'danger')
             return redirect(url_for('home'))
 
+        # == Create Initial Workout Object ============================================
         new_workout = Workout(
             cardio_log_id=cardio_log_id,
             equipment_type_id=equipment_type.equipment_type_id if equipment_type else None,
             workout_name=workout_main_container.get('name'),
             workout_date=workout_date_obj,
             target_description=workout_main_container.get('target'),
-            notes=workout_notes if workout_notes and workout_notes.strip() else None # <--- SAVE NOTES HERE
-            # total_isoreps will be populated after processing samples
+            notes=workout_notes if workout_notes and workout_notes.strip() else None # Save notes if provided
+            # Summary fields (duration, distance, split, isoreps) will be populated later
         )
         db.session.add(new_workout)
-        db.session.flush() # Get new_workout.workout_id
+        db.session.flush() # Get new_workout.workout_id for foreign key relations
 
-        # --- New MetricDescriptor handling ---
+        # == Metric Descriptor Processing ============================================
+        # -- Create or Get Metric Descriptors from JSON -------------------
         descriptors_json = workout_main_container.get('analitics', {}).get('descriptor', [])
-        metric_descriptor_map_for_samples = {} 
+        metric_descriptor_map_for_samples = {} # Maps JSON index 'i' to MetricDescriptor object
         
-        isoreps_descriptor_id = None 
+        isoreps_descriptor_id = None # To identify IsoReps metric for summary
 
         for desc_data_from_json in descriptors_json:
-            json_i = desc_data_from_json.get('i')
+            json_i = desc_data_from_json.get('i') # Index from JSON used to map samples
             metric_name_from_json = desc_data_from_json.get('pr', {}).get('name')
             unit_of_measure_from_json = desc_data_from_json.get('pr', {}).get('um')
 
-            if metric_name_from_json is None: 
+            if metric_name_from_json is None: # Skip if essential data is missing
                 current_app.logger.warning(f"Skipping descriptor due to missing name: {desc_data_from_json}")
                 continue
 
+            # -- Find or Create MetricDescriptor in DB -------------------
             metric_descriptor_entry = MetricDescriptor.query.filter_by(
                 metric_name=metric_name_from_json,
                 unit_of_measure=unit_of_measure_from_json
             ).first()
 
-            if not metric_descriptor_entry:
+            if not metric_descriptor_entry: # If descriptor doesn't exist, create it
                 try:
                     metric_descriptor_entry = MetricDescriptor(
                         metric_name=metric_name_from_json,
                         unit_of_measure=unit_of_measure_from_json
                     )
                     db.session.add(metric_descriptor_entry)
-                    db.session.flush() 
-                except IntegrityError: 
+                    db.session.flush() # Ensure ID is available
+                except IntegrityError: # Handle rare race condition if another process creates it
                     db.session.rollback()
                     metric_descriptor_entry = MetricDescriptor.query.filter_by(
                         metric_name=metric_name_from_json,
                         unit_of_measure=unit_of_measure_from_json
                     ).first()
-                    if not metric_descriptor_entry: 
+                    if not metric_descriptor_entry: # If still not found, raise error
                         raise Exception(f"Failed to create or find metric descriptor: {metric_name_from_json} ({unit_of_measure_from_json})")
 
-
+            # -- Populate Map and Identify IsoReps -------------------
             if json_i is not None and metric_descriptor_entry:
                 metric_descriptor_map_for_samples[json_i] = metric_descriptor_entry
                 if metric_name_from_json == 'IsoReps' and unit_of_measure_from_json == 'Number':
                     isoreps_descriptor_id = metric_descriptor_entry.metric_descriptor_id
         
-        # --- Process WorkoutSamples using the new map ---
+        # == Workout Sample Processing ============================================
         samples_json = workout_main_container.get('analitics', {}).get('samples', [])
-        
-        last_isoreps_value = None 
+        last_isoreps_value = None # To store the final IsoReps count for summary
         
         for sample_json in samples_json:
-            time_offset = sample_json.get('t')
-            values_from_json = sample_json.get('vs', []) 
+            time_offset = sample_json.get('t') # Time offset for the sample
+            values_from_json = sample_json.get('vs', []) # List of values, index corresponds to descriptor's 'i'
             for original_json_index, value in enumerate(values_from_json):
-                descriptor_obj = metric_descriptor_map_for_samples.get(original_json_index)
-                if descriptor_obj:
+                descriptor_obj = metric_descriptor_map_for_samples.get(original_json_index) # Get corresponding MetricDescriptor
+                if descriptor_obj: # If a descriptor exists for this sample index
                     workout_sample = WorkoutSample(
                         workout_id=new_workout.workout_id,
                         metric_descriptor_id=descriptor_obj.metric_descriptor_id,
@@ -126,36 +138,43 @@ def submit_json_workout():
                     )
                     db.session.add(workout_sample)
                     
+                    # -- Track Last IsoReps Value -------------------
                     if descriptor_obj.metric_descriptor_id == isoreps_descriptor_id:
                         last_isoreps_value = value
 
-        # --- Process summary data for Workout object (duration, distance, split, and IsoReps) ---
+        # == Workout Summary Data Population ============================================
+        # -- Initialize Summary Variables -------------------
         extracted_duration_seconds = None
         calculated_total_distance_meters = None
         calculated_average_split_seconds_500m = None
         
-        summary_entries_json = workout_main_container.get('data', [])
+        # -- Extract Duration from Summary Data -------------------
+        summary_entries_json = workout_main_container.get('data', []) # This 'data' is different from the top-level 'data'
         for entry_json in summary_entries_json:
             property_key = entry_json.get('property')
-            if property_key == 'Move': continue
+            if property_key == 'Move': continue # Skip 'Move' property
             if property_key == 'Duration':
                 try:
                     raw_duration_value = float(entry_json.get('rawValue'))
                     unit = entry_json.get('uM', '').lower()
+                    # Convert duration to seconds based on unit
                     if unit in ["min", "minute", "minutes"]: extracted_duration_seconds = raw_duration_value * 60
                     elif unit in ["h", "hour", "hours"]: extracted_duration_seconds = raw_duration_value * 3600
                     elif unit in ["ms", "millisecond", "milliseconds"]: extracted_duration_seconds = raw_duration_value / 1000.0
                     elif unit in ["s", "sec", "second", "seconds"] or not unit: extracted_duration_seconds = raw_duration_value
-                    if extracted_duration_seconds is not None: break
-                except: pass
+                    if extracted_duration_seconds is not None: break # Stop if duration found
+                except (ValueError, TypeError): pass # Ignore parsing errors for this field
         
+        # -- Calculate Total Distance from Samples -------------------
         distance_metric_descriptor_id_to_check = None
+        # Find a 'distance' metric descriptor
         for _json_idx, desc_obj_in_map in metric_descriptor_map_for_samples.items():
             if desc_obj_in_map.metric_name and 'distance' in desc_obj_in_map.metric_name.lower():
                 distance_metric_descriptor_id_to_check = desc_obj_in_map.metric_descriptor_id
                 break
         
-        if distance_metric_descriptor_id_to_check:
+        if distance_metric_descriptor_id_to_check: # If a distance descriptor was found
+            # Get the last sample for this distance metric
             last_distance_sample = WorkoutSample.query.filter_by(
                 workout_id=new_workout.workout_id,
                 metric_descriptor_id=distance_metric_descriptor_id_to_check
@@ -163,6 +182,7 @@ def submit_json_workout():
             if last_distance_sample and last_distance_sample.value is not None:
                 calculated_total_distance_meters = float(last_distance_sample.value)
         
+        # -- Fallback: Extract Distance from Summary Data if not found in samples -------------------
         if calculated_total_distance_meters is None: 
             for entry_json in summary_entries_json:
                 pkey = entry_json.get('property', '').lower()
@@ -170,47 +190,65 @@ def submit_json_workout():
                     try:
                         val = float(entry_json.get('rawValue'))
                         unit = entry_json.get('uM', '').lower()
+                        # Convert distance to meters based on unit
                         if unit == 'km': calculated_total_distance_meters = val * 1000
-                        elif unit == 'mi': calculated_total_distance_meters = val * 1609.34
+                        elif unit == 'mi': calculated_total_distance_meters = val * 1609.34 # Miles to meters
                         elif unit == 'm' or not unit: calculated_total_distance_meters = val
-                        if calculated_total_distance_meters is not None: break
-                    except: pass
+                        if calculated_total_distance_meters is not None: break # Stop if distance found
+                    except (ValueError, TypeError): pass # Ignore parsing errors
         
+        # -- Calculate Average Split -------------------
         if extracted_duration_seconds is not None and calculated_total_distance_meters is not None and calculated_total_distance_meters > 0:
             calculated_average_split_seconds_500m = (extracted_duration_seconds / calculated_total_distance_meters) * 500
         
+        # -- Update Workout Object with Summary Data -------------------
         new_workout.duration_seconds = extracted_duration_seconds
         new_workout.total_distance_meters = calculated_total_distance_meters
         new_workout.average_split_seconds_500m = calculated_average_split_seconds_500m
-        new_workout.total_isoreps = last_isoreps_value
+        new_workout.total_isoreps = last_isoreps_value # Set total IsoReps from last sample
 
-        # HeartRateSamples and WorkoutHRZones processing (remains the same)
+        # == Heart Rate Data Processing ============================================
+        # -- Process HeartRateSamples -------------------
+        # Look for HR samples in various possible locations in the JSON
         hr_samples_json = json_data.get('hr', workout_main_container.get('hr', workout_main_container.get('analitics', {}).get('hr', [])))
         if hr_samples_json:
             for hr_item in hr_samples_json:
-                if hr_item.get('hr') is not None:
+                if hr_item.get('hr') is not None: # Ensure HR value exists
                     db.session.add(HeartRateSample(workout_id=new_workout.workout_id, time_offset_seconds=hr_item.get('t'), heart_rate_bpm=hr_item.get('hr')))
         
+        # -- Process WorkoutHRZones -------------------
+        # Look for HR zones in various possible locations in the JSON
         hr_zones_json = json_data.get('hrZones', workout_main_container.get('hrZones', workout_main_container.get('analitics', {}).get('hrZones', [])))
         if hr_zones_json:
             for zone_item in hr_zones_json:
-                db.session.add(WorkoutHRZone(workout_id=new_workout.workout_id, zone_name=zone_item.get('name'), color_hex=zone_item.get('color'), lower_bound_bpm=zone_item.get('lowerBound'), upper_bound_bpm=zone_item.get('upperBound'), seconds_in_zone=zone_item.get('secondsInZone')))
+                db.session.add(WorkoutHRZone(
+                    workout_id=new_workout.workout_id, 
+                    zone_name=zone_item.get('name'), 
+                    color_hex=zone_item.get('color'), 
+                    lower_bound_bpm=zone_item.get('lowerBound'), 
+                    upper_bound_bpm=zone_item.get('upperBound'), 
+                    seconds_in_zone=zone_item.get('secondsInZone')
+                ))
 
-        db.session.commit()
+        # == Finalize Transaction ============================================
+        db.session.commit() # Commit all changes to the database
         flash('Workout data submitted successfully!', 'success')
-        return redirect(url_for('home'))
+        return redirect(url_for('home')) # Redirect to home page on success
 
-    except IntegrityError as e:
+    except IntegrityError as e: # Handle database integrity violations (e.g., unique constraints)
         db.session.rollback()
         current_app.logger.error(f"IntegrityError during workout submission: {e.orig}", exc_info=True)
         flash(f'Database integrity error: {str(e.orig)}. Could not submit workout.', 'danger')
-    except Exception as e:
+    except Exception as e: # Catch any other exceptions during processing
         db.session.rollback()
         current_app.logger.error(f'Error submitting workout: {e}', exc_info=True)
         flash(f'Error submitting workout: {str(e)}', 'danger')
     
-    return redirect(url_for('home'))
+    return redirect(url_for('home')) # Redirect to home on failure
 
-# register_routes remains the same
+# --------------------------------------------------------
+# - Route Registration
+#---------------------------------------------------------
+# Registers the JSON workout submission route with the Flask application
 def register_routes(app):
     app.add_url_rule('/submit_json_workout', endpoint='submit_json_workout', view_func=submit_json_workout, methods=['POST'])

--- a/views/submit_manual_workout.py
+++ b/views/submit_manual_workout.py
@@ -1,0 +1,91 @@
+# views/submit_manual_workout.py
+import uuid
+from flask import request, redirect, url_for, flash, current_app
+from datetime import datetime
+from models import db, EquipmentType, Workout
+from utils import parse_duration_to_seconds # Assuming you might create/use such a utility
+
+def submit_manual_workout():
+    if request.method == 'POST':
+        workout_name_form = request.form.get('workoutName')
+        date_str = request.form.get('workoutDate')
+        time_str = request.form.get('workoutTime')
+        distance_str = request.form.get('workoutDistance')
+        # level_str = request.form.get('workoutLevel') #later create new table for levels
+        notes = request.form.get('workoutNotes')
+
+        # --- Validation ---
+        if not date_str or not time_str or not distance_str:
+            flash('Date, Time, and Distance are required fields.', 'danger')
+            return redirect(url_for('home'))
+
+        workout_name = workout_name_form if workout_name_form else "Rowing"
+
+        try:
+            workout_date_obj = datetime.strptime(date_str, '%Y-%m-%d').date()
+        except ValueError:
+            flash(f'Invalid date format: {date_str}. Expected YYYY-MM-DD.', 'danger')
+            return redirect(url_for('home'))
+
+        duration_seconds_val = parse_duration_to_seconds(time_str)
+        if duration_seconds_val is None or duration_seconds_val <=0:
+            flash(f'Invalid time format: {time_str}. Use HH:MM:SS.ms, MM:SS.ms, or S.ms.', 'danger')
+            return redirect(url_for('home'))
+
+        try:
+            total_distance_meters_val = float(distance_str)
+            if total_distance_meters_val <= 0:
+                flash('Distance must be a positive number.', 'danger')
+                return redirect(url_for('home'))
+        except ValueError:
+            flash('Invalid distance format. Must be a number.', 'danger')
+            return redirect(url_for('home'))
+
+        # --- Calculate Split ---
+        average_split_val = None
+        if total_distance_meters_val > 0 and duration_seconds_val > 0:
+            average_split_val = (duration_seconds_val / total_distance_meters_val) * 500
+
+        # --- Get or Create Equipment Type ---
+        equipment_name = "Manual Entry" # Or "RowErgometer" if it's always a rower
+        equipment_type = EquipmentType.query.filter_by(name=equipment_name).first()
+        if not equipment_type:
+            equipment_type = EquipmentType(name=equipment_name)
+            db.session.add(equipment_type)
+            db.session.flush() # To get ID if new
+
+        # --- Create Workout Object ---
+        try:
+            # Generate a unique cardio_log_id for manual entries
+            # Using a combination of a prefix and a UUID to ensure uniqueness
+            cardio_log_id = f"manual_{uuid.uuid4()}"
+
+            new_workout = Workout(
+                cardio_log_id=cardio_log_id,
+                equipment_type_id=equipment_type.equipment_type_id,
+                workout_name=workout_name,
+                workout_date=workout_date_obj,
+                #target_description=level_str if level_str else None, # Using level as target description
+                duration_seconds=duration_seconds_val,
+                total_distance_meters=total_distance_meters_val,
+                average_split_seconds_500m=average_split_val,
+                total_isoreps=None,  # IsoReps are not provided in manual entry
+                notes=notes if notes else None
+            )
+            
+            db.session.add(new_workout)
+            db.session.commit()
+            flash('Manual workout added successfully!', 'success')
+            return redirect(url_for('details', workout_id=new_workout.workout_id))
+
+        except Exception as e:
+            db.session.rollback()
+            current_app.logger.error(f"Error adding manual workout: {e}", exc_info=True)
+            flash(f'Error adding manual workout: {str(e)}', 'danger')
+            return redirect(url_for('home'))
+    
+    # Should not be reached via GET if form is POST only
+    return redirect(url_for('home'))
+
+def register_routes(app):
+    app.add_url_rule('/submit_manual_workout', endpoint='submit_manual_workout', view_func=submit_manual_workout, methods=['POST'])

--- a/views/submit_manual_workout.py
+++ b/views/submit_manual_workout.py
@@ -11,7 +11,7 @@ def submit_manual_workout():
         date_str = request.form.get('workoutDate')
         time_str = request.form.get('workoutTime')
         distance_str = request.form.get('workoutDistance')
-        # level_str = request.form.get('workoutLevel') #later create new table for levels
+        level_str = request.form.get('workoutLevel')
         notes = request.form.get('workoutNotes')
 
         # --- Validation ---
@@ -41,6 +41,17 @@ def submit_manual_workout():
             flash('Invalid distance format. Must be a number.', 'danger')
             return redirect(url_for('home'))
 
+        level_val = None
+        if level_str:
+            try:
+                level_val = float(level_str) # Changed from int() to float()
+                if level_val < 0: # Assuming level should not be negative
+                    flash('Level must be a non-negative number.', 'danger')
+                    return redirect(url_for('home'))
+            except ValueError:
+                flash('Invalid level format. Must be a number (e.g., 5 or 5.5).', 'danger') # Updated flash message
+                return redirect(url_for('home'))
+
         # --- Calculate Split ---
         average_split_val = None
         if total_distance_meters_val > 0 and duration_seconds_val > 0:
@@ -65,12 +76,13 @@ def submit_manual_workout():
                 equipment_type_id=equipment_type.equipment_type_id,
                 workout_name=workout_name,
                 workout_date=workout_date_obj,
-                #target_description=level_str if level_str else None, # Using level as target description
+                target_description=None, 
                 duration_seconds=duration_seconds_val,
                 total_distance_meters=total_distance_meters_val,
                 average_split_seconds_500m=average_split_val,
-                total_isoreps=None,  # IsoReps are not provided in manual entry
-                notes=notes if notes else None
+                total_isoreps=None,
+                notes=notes if notes else None,
+                level=level_val
             )
             
             db.session.add(new_workout)

--- a/views/weeklysummary.py
+++ b/views/weeklysummary.py
@@ -1,0 +1,78 @@
+# ========================================================
+# = weeklysummary.py - View for displaying paginated weekly workout summaries
+# ========================================================
+from flask import render_template, redirect, url_for, current_app
+from sqlalchemy import text
+from models import db # Assuming db is initialized and available
+from utils import CustomPagination # Import CustomPagination
+
+# --------------------------------------------------------
+# - Weekly Summary View Function
+#---------------------------------------------------------
+# Displays paginated weekly workout summaries from the mv_week_totals materialized view.
+def weeklysummary(page_num=1):
+    # == Pagination Configuration ============================================
+    per_page_value = current_app.config.get('PER_PAGE', 10) # Get items per page from app config
+
+    # == Query Total Count for Pagination ============================================
+    count_result = db.session.execute(text("SELECT COUNT(*) FROM mv_week_totals")).scalar()
+    total_pages = (count_result + per_page_value - 1) // per_page_value if count_result > 0 else 1
+
+    # == Page Number Validation and Redirection ============================================
+    if page_num < 1:
+        page_num = 1
+    elif page_num > total_pages and total_pages > 0:
+        return redirect(url_for('weeklysummary_paginated', page_num=total_pages))
+    elif page_num > total_pages and total_pages == 0: # If no data, redirect to page 1
+        return redirect(url_for('weeklysummary_paginated', page_num=1))
+
+
+    # == Calculate Offset for SQL Query ============================================
+    offset = (page_num - 1) * per_page_value
+
+    # == Query Data for Current Page ============================================
+    weeklysummary_raw_results = db.session.execute(text(f"""
+        SELECT
+            week_start_date,
+            total_meters_rowed,
+            total_seconds_rowed,
+            average_split_seconds_per_500m AS split,
+            total_isoreps_sum
+        FROM
+            mv_week_totals
+        ORDER BY
+            week_start_date DESC
+        LIMIT :limit OFFSET :offset
+    """), {'limit': per_page_value, 'offset': offset}).fetchall()
+
+    # == Prepare Data for Template ============================================
+    weeklysummary_display_data = []
+    for row in weeklysummary_raw_results:
+        iso_calendar = row.week_start_date.isocalendar()
+        weeklysummary_display_data.append({
+            'year': iso_calendar[0],
+            'week_number': iso_calendar[1],
+            'meters': float(row.total_meters_rowed) if row.total_meters_rowed is not None else 0,
+            'seconds': float(row.total_seconds_rowed) if row.total_seconds_rowed is not None else 0,
+            'split': float(row.split) if row.split is not None else 0,
+            'isoreps': float(row.total_isoreps_sum) if row.total_isoreps_sum is not None else 0
+        })
+
+    # == Custom Pagination Object ============================================
+    weeklysummary_pagination = CustomPagination(page_num, per_page_value, count_result, weeklysummary_display_data)
+
+    # == Render Template ============================================
+    return render_template(
+        'weeklysummary.html',
+        weeklysummary_pagination=weeklysummary_pagination,
+        weeklysummary_display_data=weeklysummary_display_data,
+        page_title="Weekly Workout Summaries"
+    )
+
+# --------------------------------------------------------
+# - Route Registration
+#---------------------------------------------------------
+# Registers the weekly summary view routes with the Flask application.
+def register_routes(app):
+    app.add_url_rule('/weeklysummary/', endpoint='weeklysummary', view_func=lambda: weeklysummary(1), methods=['GET'])
+    app.add_url_rule('/weeklysummary/page/<int:page_num>', endpoint='weeklysummary_paginated', view_func=weeklysummary, methods=['GET'])

--- a/views/workouts_by_date.py
+++ b/views/workouts_by_date.py
@@ -28,7 +28,8 @@ def show_workouts_for_date(date_str):
                 SELECT
                     total_meters_rowed,
                     total_seconds_rowed,
-                    average_split_seconds_per_500m AS split
+                    average_split_seconds_per_500m AS split,
+                    total_isoreps_sum
                 FROM
                     mv_day_totals
                 WHERE
@@ -41,14 +42,15 @@ def show_workouts_for_date(date_str):
             daily_summary_data = {
                 'meters': float(summary_result.total_meters_rowed) if summary_result.total_meters_rowed is not None else 0,
                 'seconds': float(summary_result.total_seconds_rowed) if summary_result.total_seconds_rowed is not None else 0,
-                'split': float(summary_result.split) if summary_result.split is not None else 0
+                'split': float(summary_result.split) if summary_result.split is not None else 0,
+                'isoreps': float(summary_result.total_isoreps_sum) if summary_result.total_isoreps_sum is not None else 0
             }
         else: # If no summary found, provide default values
-            daily_summary_data = {'meters': 0, 'seconds': 0, 'split': 0}
+            daily_summary_data = {'meters': 0, 'seconds': 0, 'split': 0, 'isoreps': 0}
             
     except Exception as e: # Handle potential database errors
         current_app.logger.error(f"Error fetching daily summary for date {selected_date}: {e}", exc_info=True)
-        daily_summary_data = {'meters': 0, 'seconds': 0, 'split': 0} # Default on error
+        daily_summary_data = {'meters': 0, 'seconds': 0, 'split': 0, 'isoreps': 0} # Default on error
         flash("Could not retrieve daily summary statistics.", "warning")
 
 

--- a/views/workouts_by_date.py
+++ b/views/workouts_by_date.py
@@ -1,23 +1,28 @@
-# views/workouts_by_date.py
+# ========================================================
+# = workouts_by_date.py - View for displaying workouts for a specific date
+# ========================================================
 from flask import render_template, abort, flash, redirect, url_for, current_app
-from models import db, Workout # Added db
-from sqlalchemy import text # Added text
+from models import db, Workout
+from sqlalchemy import text
 from datetime import datetime
 
+# --------------------------------------------------------
+# - Show Workouts for Date View Function
+#---------------------------------------------------------
+# Displays all workouts for a specific date, along with a summary for that day.
+# The date_str is expected in 'YYYY-MM-DD' format.
 def show_workouts_for_date(date_str):
-    """
-    Displays all workouts for a specific date, along with a summary for that day.
-    The date_str is expected in 'YYYY-MM-DD' format.
-    """
+    # == Date Parsing and Validation ============================================
     try:
-        selected_date = datetime.strptime(date_str, '%Y-%m-%d').date()
-    except ValueError:
+        selected_date = datetime.strptime(date_str, '%Y-%m-%d').date() # Convert string to date object
+    except ValueError: # Handle invalid date format
         flash('Invalid date format provided.', 'danger')
-        return redirect(url_for('dailysummary'))
+        return redirect(url_for('dailysummary')) # Redirect if date is invalid
 
-    # --- Fetch Daily Summary ---
+    # == Fetch Daily Summary from Materialized View ============================================
     daily_summary_data = None
     try:
+        # -- Execute SQL Query for Daily Totals -------------------
         summary_result = db.session.execute(
             text("""
                 SELECT
@@ -29,46 +34,50 @@ def show_workouts_for_date(date_str):
                 WHERE
                     day_date = :selected_date
             """),
-            {'selected_date': selected_date}
+            {'selected_date': selected_date} # Bind selected_date to the query
         ).fetchone()
 
-        if summary_result:
+        if summary_result: # If summary data exists for the date
             daily_summary_data = {
                 'meters': float(summary_result.total_meters_rowed) if summary_result.total_meters_rowed is not None else 0,
                 'seconds': float(summary_result.total_seconds_rowed) if summary_result.total_seconds_rowed is not None else 0,
                 'split': float(summary_result.split) if summary_result.split is not None else 0
             }
-        else:
-            # If no summary found for the day (e.g., no workouts, or MV not refreshed), provide defaults
+        else: # If no summary found, provide default values
             daily_summary_data = {'meters': 0, 'seconds': 0, 'split': 0}
             
-    except Exception as e:
+    except Exception as e: # Handle potential database errors
         current_app.logger.error(f"Error fetching daily summary for date {selected_date}: {e}", exc_info=True)
-        # Provide default summary data in case of error
-        daily_summary_data = {'meters': 0, 'seconds': 0, 'split': 0}
+        daily_summary_data = {'meters': 0, 'seconds': 0, 'split': 0} # Default on error
         flash("Could not retrieve daily summary statistics.", "warning")
 
 
-    # --- Fetch Individual Workouts ---
+    # == Fetch Individual Workouts for the Selected Date ============================================
     workouts_on_date = Workout.query.filter(
-        Workout.workout_date == selected_date
-    ).order_by(Workout.workout_id.asc()).all()
+        Workout.workout_date == selected_date # Filter workouts by the selected date
+    ).order_by(Workout.workout_id.asc()).all() # Order by ID for consistency
 
+    # == Prepare Workout Data for Template ============================================
     workouts_display_data = []
-    for workout_item in workouts_on_date:
+    for workout_item in workouts_on_date: # Iterate through workouts found for the date
         workouts_display_data.append({
-            'workout_obj': workout_item,
-            'name': workout_item.workout_name
+            'workout_obj': workout_item, # Pass the raw workout object
+            'name': workout_item.workout_name # Include workout name for easy access in template
         })
 
+    # == Render Template ============================================
     return render_template(
         'workouts_by_date.html',
-        selected_date=selected_date,
-        selected_date_str=selected_date.strftime('%A, %B %d, %Y'),
-        daily_summary_data=daily_summary_data, # Pass summary to template
-        workouts_display_data=workouts_display_data
+        selected_date=selected_date, # Pass the date object
+        selected_date_str=selected_date.strftime('%A, %B %d, %Y'), # Pass formatted date string
+        daily_summary_data=daily_summary_data, # Pass daily summary statistics
+        workouts_display_data=workouts_display_data # Pass list of workouts for the day
     )
 
+# --------------------------------------------------------
+# - Route Registration
+#---------------------------------------------------------
+# Registers the workouts by date view route with the Flask application
 def register_routes(app):
     app.add_url_rule('/workouts/date/<string:date_str>', 
                      endpoint='workouts_by_date', 

--- a/views/workouts_by_month.py
+++ b/views/workouts_by_month.py
@@ -1,0 +1,217 @@
+# ========================================================
+# = workouts_by_month.py - View for displaying workouts for a specific month
+# ========================================================
+from flask import render_template, flash, redirect, url_for, current_app
+from models import db
+from sqlalchemy import text
+from datetime import datetime, timedelta
+import calendar
+
+# --------------------------------------------------------
+# - Show Workouts for Specific Month View Function
+#---------------------------------------------------------
+# Displays a summary for a specific month, then weekly and daily summaries within that month.
+# The year_month_str is expected in 'YYYY-MM' format (e.g., '2023-08').
+def show_workouts_for_month(year_month_str):
+    # == Month Parsing and Validation ============================================
+    try:
+        year_str, month_str = year_month_str.split('-')
+        year = int(year_str)
+        month = int(month_str)
+        if not (1 <= month <= 12):
+            raise ValueError("Month out of range.")
+        
+        # Get the first and last day of the month
+        month_start_date = datetime(year, month, 1).date()
+        num_days_in_month = calendar.monthrange(year, month)[1]
+        month_end_date = datetime(year, month, num_days_in_month).date()
+
+    except ValueError:
+        flash(f'Invalid month format: {year_month_str}. Expected YYYY-MM (e.g., 2023-08).', 'danger')
+        return redirect(url_for('monthlysummary'))
+
+    # == Fetch Overall Monthly Summary from Materialized View ============================================
+    month_summary_data = None
+    try:
+        summary_result = db.session.execute(
+            text("""
+                SELECT
+                    total_meters_rowed,
+                    total_seconds_rowed,
+                    average_split_seconds_per_500m AS split,
+                    total_isoreps_sum
+                FROM
+                    mv_month_totals
+                WHERE
+                    year = :year AND month = :month
+            """),
+            {'year': year, 'month': month}
+        ).fetchone()
+
+        if summary_result:
+            month_summary_data = {
+                'meters': float(summary_result.total_meters_rowed) if summary_result.total_meters_rowed is not None else 0,
+                'seconds': float(summary_result.total_seconds_rowed) if summary_result.total_seconds_rowed is not None else 0,
+                'split': float(summary_result.split) if summary_result.split is not None else 0,
+                'isoreps': float(summary_result.total_isoreps_sum) if summary_result.total_isoreps_sum is not None else 0
+            }
+        else:
+            month_summary_data = {'meters': 0, 'seconds': 0, 'split': 0, 'isoreps': 0}
+            
+    except Exception as e:
+        current_app.logger.error(f"Error fetching monthly summary for {year}-{month}: {e}", exc_info=True)
+        month_summary_data = {'meters': 0, 'seconds': 0, 'split': 0, 'isoreps': 0}
+        flash("Could not retrieve monthly summary statistics.", "warning")
+
+    # == Fetch Weekly Summaries within the Selected Month ============================================
+    # A week is included if its start date is in the month OR its end date is in the month
+    # More simply, fetch weeks whose start_date is between the first day of the month's week and the last day of the month.
+    
+    first_day_of_month_week_start = month_start_date - timedelta(days=month_start_date.weekday())
+    last_day_of_month_week_end = month_end_date + timedelta(days=(6 - month_end_date.weekday()))
+
+    # == Determine all weeks that overlap with the selected month =================================
+    all_overlapping_week_starts = []
+    # Start from the Monday of the week containing the first day of the month
+    current_week_iter_start = month_start_date - timedelta(days=month_start_date.weekday()) 
+    
+    while current_week_iter_start <= month_end_date:
+        all_overlapping_week_starts.append(current_week_iter_start)
+        current_week_iter_start += timedelta(days=7)
+
+    # == Fetch Weekly Summaries from mv_week_totals for these weeks =================================
+    weekly_summaries_in_month = []
+    db_weekly_data_map = {} # To store data fetched from mv_week_totals
+
+    if all_overlapping_week_starts:
+        try:
+            # Fetch data for all potentially relevant weeks in one go
+            min_queried_week_start = all_overlapping_week_starts[0]
+            max_queried_week_start = all_overlapping_week_starts[-1]
+
+            weekly_results_from_db = db.session.execute(
+                text("""
+                    SELECT
+                        week_start_date,
+                        total_meters_rowed,
+                        total_seconds_rowed,
+                        average_split_seconds_per_500m AS split,
+                        total_isoreps_sum
+                    FROM
+                        mv_week_totals
+                    WHERE
+                        week_start_date >= :min_wsd AND week_start_date <= :max_wsd
+                """),
+                {'min_wsd': min_queried_week_start, 'max_wsd': max_queried_week_start}
+            ).fetchall()
+            
+            for row in weekly_results_from_db:
+                # Only map data for weeks we've identified as overlapping
+                if row.week_start_date in all_overlapping_week_starts:
+                    db_weekly_data_map[row.week_start_date] = row
+        except Exception as e:
+            current_app.logger.error(f"Error fetching weekly summaries for month {year}-{month}: {e}", exc_info=True)
+            flash("Could not retrieve some weekly summaries for the selected month.", "warning")
+
+    # == Populate weekly_summaries_in_month, including placeholders for empty weeks =================
+    for week_start_date_loop in all_overlapping_week_starts:
+        iso_cal = week_start_date_loop.isocalendar()
+        week_end_date_loop = week_start_date_loop + timedelta(days=6)
+
+        if week_start_date_loop in db_weekly_data_map:
+            row_data = db_weekly_data_map[week_start_date_loop]
+            weekly_summaries_in_month.append({
+                'week_start_date': row_data.week_start_date,
+                'week_end_date_display': week_end_date_loop,
+                'year': iso_cal[0],
+                'week_number': iso_cal[1],
+                'meters': float(row_data.total_meters_rowed) if row_data.total_meters_rowed is not None else 0,
+                'seconds': float(row_data.total_seconds_rowed) if row_data.total_seconds_rowed is not None else 0,
+                'split': float(row_data.split) if row_data.split is not None else 0,
+                'isoreps': float(row_data.total_isoreps_sum) if row_data.total_isoreps_sum is not None else 0,
+                'has_workouts': True 
+            })
+        else:
+            # This week had no workouts in mv_week_totals, create a placeholder
+            weekly_summaries_in_month.append({
+                'week_start_date': week_start_date_loop,
+                'week_end_date_display': week_end_date_loop,
+                'year': iso_cal[0],
+                'week_number': iso_cal[1],
+                'meters': 0,
+                'seconds': 0,
+                'split': 0,
+                'isoreps': 0,
+                'has_workouts': False 
+            })
+
+    # == Fetch Daily Summaries for each day in the Selected Month ============================================
+    daily_summaries_in_month = []
+    try:
+        daily_results = db.session.execute(
+            text("""
+                SELECT
+                    day_date,
+                    total_meters_rowed,
+                    total_seconds_rowed,
+                    average_split_seconds_per_500m AS split,
+                    total_isoreps_sum
+                FROM
+                    mv_day_totals
+                WHERE
+                    day_date >= :start_date AND day_date <= :end_date
+                ORDER BY
+                    day_date ASC
+            """),
+            {'start_date': month_start_date, 'end_date': month_end_date}
+        ).fetchall()
+
+        daily_data_map = {row.day_date: row for row in daily_results}
+        current_day = month_start_date
+        while current_day <= month_end_date:
+            if current_day in daily_data_map:
+                row = daily_data_map[current_day]
+                daily_summaries_in_month.append({
+                    'day_date': row.day_date,
+                    'meters': float(row.total_meters_rowed) if row.total_meters_rowed is not None else 0,
+                    'seconds': float(row.total_seconds_rowed) if row.total_seconds_rowed is not None else 0,
+                    'split': float(row.split) if row.split is not None else 0,
+                    'isoreps': float(row.total_isoreps_sum) if row.total_isoreps_sum is not None else 0,
+                    'has_workouts': True
+                })
+            else:
+                daily_summaries_in_month.append({
+                    'day_date': current_day, 'meters': 0, 'seconds': 0, 'split': 0, 'isoreps': 0, 'has_workouts': False
+                })
+            current_day += timedelta(days=1)
+            
+    except Exception as e:
+        current_app.logger.error(f"Error fetching daily summaries for month {year}-{month}: {e}", exc_info=True)
+        flash("Could not retrieve daily summaries for the selected month.", "warning")
+        daily_summaries_in_month = [] # Clear if error
+        current_day = month_start_date
+        while current_day <= month_end_date: # Still provide day structure
+            daily_summaries_in_month.append({
+                'day_date': current_day, 'meters': 0, 'seconds': 0, 'split': 0, 'isoreps': 0, 'has_workouts': False
+            })
+            current_day += timedelta(days=1)
+
+    # == Render Template ============================================
+    return render_template(
+        'workouts_by_month.html',
+        year=year,
+        month=month,
+        selected_month_str=month_start_date.strftime('%B %Y'),
+        month_summary_data=month_summary_data,
+        weekly_summaries_in_month=weekly_summaries_in_month,
+        daily_summaries_in_month=daily_summaries_in_month
+    )
+
+# --------------------------------------------------------
+# - Route Registration
+#---------------------------------------------------------
+def register_routes(app):
+    app.add_url_rule('/workouts/month/<string:year_month_str>', 
+                     endpoint='workouts_by_month_detail', 
+                     view_func=show_workouts_for_month, 
+                     methods=['GET'])

--- a/views/workouts_by_week.py
+++ b/views/workouts_by_week.py
@@ -1,0 +1,143 @@
+# ========================================================
+# = workouts_by_week.py - View for displaying workouts for a specific week
+# ========================================================
+from flask import render_template, flash, redirect, url_for, current_app
+from models import db, Workout # Workout model might not be directly needed here anymore
+from sqlalchemy import text
+from datetime import datetime, timedelta
+
+# --------------------------------------------------------
+# - Show Workouts for Specific Week View Function
+#---------------------------------------------------------
+# Displays a summary for a specific week, and then daily summaries for each day in that week.
+# The year_week_str is expected in 'YYYY-Www' format (e.g., '2023-W35').
+def show_workouts_for_week(year_week_str):
+    # == Week Parsing and Validation ============================================
+    try:
+        year_str, week_str = year_week_str.split('-W')
+        year = int(year_str)
+        week_number = int(week_str)
+        if not (1 <= week_number <= 53): # ISO weeks can go up to 53
+            raise ValueError("Week number out of range.")
+        # Monday is day 1 for fromisocalendar
+        week_start_date = datetime.fromisocalendar(year, week_number, 1).date()
+        week_end_date = week_start_date + timedelta(days=6) # Sunday
+    except ValueError:
+        flash(f'Invalid week format: {year_week_str}. Expected YYYY-Www (e.g., 2023-W35).', 'danger')
+        return redirect(url_for('weeklysummary')) 
+
+    # == Fetch Overall Weekly Summary from Materialized View ============================================
+    week_summary_data = None
+    try:
+        summary_result = db.session.execute(
+            text("""
+                SELECT
+                    total_meters_rowed,
+                    total_seconds_rowed,
+                    average_split_seconds_per_500m AS split,
+                    total_isoreps_sum
+                FROM
+                    mv_week_totals
+                WHERE
+                    week_start_date = :selected_week_start_date
+            """),
+            {'selected_week_start_date': week_start_date}
+        ).fetchone()
+
+        if summary_result:
+            week_summary_data = {
+                'meters': float(summary_result.total_meters_rowed) if summary_result.total_meters_rowed is not None else 0,
+                'seconds': float(summary_result.total_seconds_rowed) if summary_result.total_seconds_rowed is not None else 0,
+                'split': float(summary_result.split) if summary_result.split is not None else 0,
+                'isoreps': float(summary_result.total_isoreps_sum) if summary_result.total_isoreps_sum is not None else 0
+            }
+        else:
+            week_summary_data = {'meters': 0, 'seconds': 0, 'split': 0, 'isoreps': 0}
+            
+    except Exception as e:
+        current_app.logger.error(f"Error fetching weekly summary for week starting {week_start_date}: {e}", exc_info=True)
+        week_summary_data = {'meters': 0, 'seconds': 0, 'split': 0, 'isoreps': 0}
+        flash("Could not retrieve weekly summary statistics for the selected week.", "warning")
+
+    # == Fetch Daily Summaries for each day in the Selected Week ============================================
+    daily_summaries_in_week = []
+    try:
+        daily_results = db.session.execute(
+            text("""
+                SELECT
+                    day_date,
+                    total_meters_rowed,
+                    total_seconds_rowed,
+                    average_split_seconds_per_500m AS split,
+                    total_isoreps_sum
+                FROM
+                    mv_day_totals
+                WHERE
+                    day_date >= :start_date AND day_date <= :end_date
+                ORDER BY
+                    day_date ASC
+            """),
+            {'start_date': week_start_date, 'end_date': week_end_date}
+        ).fetchall()
+
+        # Create a dictionary for quick lookup
+        daily_data_map = {row.day_date: row for row in daily_results}
+
+        # Iterate through all days of the week to ensure all days are represented
+        current_day = week_start_date
+        while current_day <= week_end_date:
+            if current_day in daily_data_map:
+                row = daily_data_map[current_day]
+                daily_summaries_in_week.append({
+                    'day_date': row.day_date,
+                    'meters': float(row.total_meters_rowed) if row.total_meters_rowed is not None else 0,
+                    'seconds': float(row.total_seconds_rowed) if row.total_seconds_rowed is not None else 0,
+                    'split': float(row.split) if row.split is not None else 0,
+                    'isoreps': float(row.total_isoreps_sum) if row.total_isoreps_sum is not None else 0,
+                    'has_workouts': True # Indicates data came from mv_day_totals
+                })
+            else:
+                # Add a placeholder for days with no workouts
+                daily_summaries_in_week.append({
+                    'day_date': current_day,
+                    'meters': 0,
+                    'seconds': 0,
+                    'split': 0,
+                    'isoreps': 0,
+                    'has_workouts': False # Indicates no data in mv_day_totals
+                })
+            current_day += timedelta(days=1)
+            
+    except Exception as e:
+        current_app.logger.error(f"Error fetching daily summaries for week starting {week_start_date}: {e}", exc_info=True)
+        flash("Could not retrieve daily summaries for the selected week.", "warning")
+        # Populate with empty days if error occurs
+        daily_summaries_in_week = []
+        current_day = week_start_date
+        while current_day <= week_end_date:
+            daily_summaries_in_week.append({
+                'day_date': current_day, 'meters': 0, 'seconds': 0, 'split': 0, 'isoreps': 0, 'has_workouts': False
+            })
+            current_day += timedelta(days=1)
+
+
+    # == Render Template ============================================
+    return render_template(
+        'workouts_by_week.html',
+        year=year,
+        week_number=week_number,
+        week_start_date_obj=week_start_date, # Pass date objects for potential use
+        week_end_date_obj=week_end_date,     # Pass date objects for potential use
+        selected_week_str=f"Week {week_number}, {year} ({week_start_date.strftime('%b %d')} - {week_end_date.strftime('%b %d, %Y')})",
+        week_summary_data=week_summary_data,
+        daily_summaries_in_week=daily_summaries_in_week # Pass the list of daily summaries
+    )
+
+# --------------------------------------------------------
+# - Route Registration
+#---------------------------------------------------------
+def register_routes(app):
+    app.add_url_rule('/workouts/week/<string:year_week_str>', 
+                     endpoint='workouts_by_week_detail', 
+                     view_func=show_workouts_for_week, 
+                     methods=['GET'])

--- a/views/workouts_by_year.py
+++ b/views/workouts_by_year.py
@@ -1,0 +1,196 @@
+# ========================================================
+# = workouts_by_year.py - View for displaying workout details for a specific year
+# ========================================================
+from flask import render_template, flash, redirect, url_for, current_app
+from models import db
+from sqlalchemy import text
+from datetime import datetime, timedelta
+import calendar
+
+# --------------------------------------------------------
+# - Show Workouts for Specific Year View Function
+#---------------------------------------------------------
+# Displays a summary for a specific year, then monthly and weekly summaries within that year.
+# The year_param is expected as a string (e.g., '2023').
+def show_workouts_for_year(year_param):
+    # == Year Parsing and Validation ============================================
+    try:
+        year = int(year_param)
+        # Define start and end dates for the year
+        year_start_date = datetime(year, 1, 1).date()
+        year_end_date = datetime(year, 12, 31).date()
+    except ValueError:
+        flash(f'Invalid year format: {year_param}. Expected YYYY (e.g., 2023).', 'danger')
+        return redirect(url_for('yearlysummary'))
+
+    # == Fetch Overall Yearly Summary from Materialized View ============================================
+    year_summary_data = None
+    try:
+        summary_result = db.session.execute(
+            text("""
+                SELECT
+                    total_meters_rowed,
+                    total_seconds_rowed,
+                    average_split_seconds_per_500m AS split,
+                    total_isoreps_sum
+                FROM
+                    mv_year_totals
+                WHERE
+                    year = :selected_year
+            """),
+            {'selected_year': year}
+        ).fetchone()
+
+        if summary_result:
+            year_summary_data = {
+                'meters': float(summary_result.total_meters_rowed) if summary_result.total_meters_rowed is not None else 0,
+                'seconds': float(summary_result.total_seconds_rowed) if summary_result.total_seconds_rowed is not None else 0,
+                'split': float(summary_result.split) if summary_result.split is not None else 0,
+                'isoreps': float(summary_result.total_isoreps_sum) if summary_result.total_isoreps_sum is not None else 0
+            }
+        else:
+            year_summary_data = {'meters': 0, 'seconds': 0, 'split': 0, 'isoreps': 0}
+            
+    except Exception as e:
+        current_app.logger.error(f"Error fetching yearly summary for {year}: {e}", exc_info=True)
+        year_summary_data = {'meters': 0, 'seconds': 0, 'split': 0, 'isoreps': 0}
+        flash("Could not retrieve yearly summary statistics.", "warning")
+
+    # == Fetch Monthly Summaries for the Selected Year ============================================
+    monthly_summaries_in_year = []
+    db_monthly_data_map = {}
+    try:
+        monthly_results_from_db = db.session.execute(
+            text("""
+                SELECT
+                    month,
+                    total_meters_rowed,
+                    total_seconds_rowed,
+                    average_split_seconds_per_500m AS split,
+                    total_isoreps_sum
+                FROM
+                    mv_month_totals
+                WHERE
+                    year = :selected_year
+                ORDER BY
+                    month ASC
+            """),
+            {'selected_year': year}
+        ).fetchall()
+        for row in monthly_results_from_db:
+            db_monthly_data_map[int(row.month)] = row
+            
+    except Exception as e:
+        current_app.logger.error(f"Error fetching monthly summaries for year {year}: {e}", exc_info=True)
+        flash("Could not retrieve monthly summaries for the selected year.", "warning")
+
+    for month_num in range(1, 13):
+        month_name_str = datetime(year, month_num, 1).strftime('%B')
+        if month_num in db_monthly_data_map:
+            row_data = db_monthly_data_map[month_num]
+            monthly_summaries_in_year.append({
+                'year': year,
+                'month': month_num,
+                'month_name': month_name_str,
+                'meters': float(row_data.total_meters_rowed) if row_data.total_meters_rowed is not None else 0,
+                'seconds': float(row_data.total_seconds_rowed) if row_data.total_seconds_rowed is not None else 0,
+                'split': float(row_data.split) if row_data.split is not None else 0,
+                'isoreps': float(row_data.total_isoreps_sum) if row_data.total_isoreps_sum is not None else 0,
+                'has_workouts': True
+            })
+        else:
+            monthly_summaries_in_year.append({
+                'year': year, 'month': month_num, 'month_name': month_name_str,
+                'meters': 0, 'seconds': 0, 'split': 0, 'isoreps': 0, 'has_workouts': False
+            })
+
+    # == Fetch Weekly Summaries for the Selected Year ============================================
+    # Identify all ISO weeks that overlap with the year
+    all_overlapping_week_starts_for_year = []
+    # Start from the Monday of the week containing Jan 1st
+    current_week_iter_start_for_year = year_start_date - timedelta(days=year_start_date.weekday())
+    
+    while current_week_iter_start_for_year <= year_end_date:
+        all_overlapping_week_starts_for_year.append(current_week_iter_start_for_year)
+        current_week_iter_start_for_year += timedelta(days=7)
+
+    weekly_summaries_in_year = []
+    db_weekly_data_map_for_year = {}
+
+    if all_overlapping_week_starts_for_year:
+        try:
+            min_queried_week_start_yr = all_overlapping_week_starts_for_year[0]
+            max_queried_week_start_yr = all_overlapping_week_starts_for_year[-1]
+
+            weekly_results_from_db_yr = db.session.execute(
+                text("""
+                    SELECT
+                        week_start_date,
+                        total_meters_rowed,
+                        total_seconds_rowed,
+                        average_split_seconds_per_500m AS split,
+                        total_isoreps_sum
+                    FROM
+                        mv_week_totals
+                    WHERE
+                        week_start_date >= :min_wsd AND week_start_date <= :max_wsd
+                """),
+                {'min_wsd': min_queried_week_start_yr, 'max_wsd': max_queried_week_start_yr}
+            ).fetchall()
+            
+            for row in weekly_results_from_db_yr:
+                if row.week_start_date in all_overlapping_week_starts_for_year:
+                     db_weekly_data_map_for_year[row.week_start_date] = row
+        except Exception as e:
+            current_app.logger.error(f"Error fetching weekly summaries for year {year}: {e}", exc_info=True)
+            flash("Could not retrieve some weekly summaries for the selected year.", "warning")
+
+    for week_start_dt_loop_yr in all_overlapping_week_starts_for_year:
+        iso_cal_yr = week_start_dt_loop_yr.isocalendar()
+        week_end_dt_loop_yr = week_start_dt_loop_yr + timedelta(days=6)
+
+        # Ensure the week is primarily within the target year for display logic
+        # (e.g. week 53 of previous year might start in Dec but belong to current year by ISO rules)
+        # Or week 1 of next year might start in current year.
+        # We are interested in weeks that have ANY day in the current year.
+        # The all_overlapping_week_starts_for_year logic already handles this.
+
+        if week_start_dt_loop_yr in db_weekly_data_map_for_year:
+            row_data_yr = db_weekly_data_map_for_year[week_start_dt_loop_yr]
+            weekly_summaries_in_year.append({
+                'week_start_date': row_data_yr.week_start_date,
+                'week_end_date_display': week_end_dt_loop_yr,
+                'year': iso_cal_yr[0], # This might be prev/next year for weeks straddling year boundary
+                'week_number': iso_cal_yr[1],
+                'meters': float(row_data_yr.total_meters_rowed) if row_data_yr.total_meters_rowed is not None else 0,
+                'seconds': float(row_data_yr.total_seconds_rowed) if row_data_yr.total_seconds_rowed is not None else 0,
+                'split': float(row_data_yr.split) if row_data_yr.split is not None else 0,
+                'isoreps': float(row_data_yr.total_isoreps_sum) if row_data_yr.total_isoreps_sum is not None else 0,
+                'has_workouts': True 
+            })
+        else:
+            weekly_summaries_in_year.append({
+                'week_start_date': week_start_dt_loop_yr,
+                'week_end_date_display': week_end_dt_loop_yr,
+                'year': iso_cal_yr[0],
+                'week_number': iso_cal_yr[1],
+                'meters': 0, 'seconds': 0, 'split': 0, 'isoreps': 0, 'has_workouts': False
+            })
+            
+    # == Render Template ============================================
+    return render_template(
+        'workouts_by_year.html',
+        selected_year_str=str(year),
+        year_summary_data=year_summary_data,
+        monthly_summaries_in_year=monthly_summaries_in_year,
+        weekly_summaries_in_year=weekly_summaries_in_year
+    )
+
+# --------------------------------------------------------
+# - Route Registration
+#---------------------------------------------------------
+def register_routes(app):
+    app.add_url_rule('/workouts/year/<string:year_param>', 
+                     endpoint='workouts_by_year_detail', 
+                     view_func=show_workouts_for_year, 
+                     methods=['GET'])

--- a/views/yearlysummary.py
+++ b/views/yearlysummary.py
@@ -1,0 +1,75 @@
+# ========================================================
+# = yearlysummary.py - View for displaying paginated yearly workout summaries
+# ========================================================
+from flask import render_template, redirect, url_for, current_app
+from sqlalchemy import text
+from models import db 
+from utils import CustomPagination 
+
+# --------------------------------------------------------
+# - Yearly Summary View Function
+#---------------------------------------------------------
+# Displays paginated yearly workout summaries from the mv_year_totals materialized view.
+def yearlysummary(page_num=1):
+    # == Pagination Configuration ============================================
+    per_page_value = current_app.config.get('PER_PAGE', 10) 
+
+    # == Query Total Count for Pagination ============================================
+    count_result = db.session.execute(text("SELECT COUNT(*) FROM mv_year_totals")).scalar()
+    total_pages = (count_result + per_page_value - 1) // per_page_value if count_result > 0 else 1
+
+    # == Page Number Validation and Redirection ============================================
+    if page_num < 1:
+        page_num = 1
+    elif page_num > total_pages and total_pages > 0:
+        return redirect(url_for('yearlysummary_paginated', page_num=total_pages))
+    elif page_num > total_pages and total_pages == 0: 
+        return redirect(url_for('yearlysummary_paginated', page_num=1))
+
+    # == Calculate Offset for SQL Query ============================================
+    offset = (page_num - 1) * per_page_value
+
+    # == Query Data for Current Page ============================================
+    yearlysummary_raw_results = db.session.execute(text(f"""
+        SELECT
+            year,
+            total_meters_rowed,
+            total_seconds_rowed,
+            average_split_seconds_per_500m AS split,
+            total_isoreps_sum
+        FROM
+            mv_year_totals
+        ORDER BY
+            year DESC
+        LIMIT :limit OFFSET :offset
+    """), {'limit': per_page_value, 'offset': offset}).fetchall()
+
+    # == Prepare Data for Template ============================================
+    yearlysummary_display_data = []
+    for row in yearlysummary_raw_results:
+        yearlysummary_display_data.append({
+            'year': int(row.year),
+            'meters': float(row.total_meters_rowed) if row.total_meters_rowed is not None else 0,
+            'seconds': float(row.total_seconds_rowed) if row.total_seconds_rowed is not None else 0,
+            'split': float(row.split) if row.split is not None else 0,
+            'isoreps': float(row.total_isoreps_sum) if row.total_isoreps_sum is not None else 0
+        })
+
+    # == Custom Pagination Object ============================================
+    yearlysummary_pagination = CustomPagination(page_num, per_page_value, count_result, yearlysummary_display_data)
+
+    # == Render Template ============================================
+    return render_template(
+        'yearlysummary.html',
+        yearlysummary_pagination=yearlysummary_pagination,
+        yearlysummary_display_data=yearlysummary_display_data,
+        page_title="Yearly Workout Summaries"
+    )
+
+# --------------------------------------------------------
+# - Route Registration
+#---------------------------------------------------------
+# Registers the yearly summary view routes with the Flask application.
+def register_routes(app):
+    app.add_url_rule('/yearlysummary/', endpoint='yearlysummary', view_func=lambda: yearlysummary(1), methods=['GET'])
+    app.add_url_rule('/yearlysummary/page/<int:page_num>', endpoint='yearlysummary_paginated', view_func=yearlysummary, methods=['GET'])


### PR DESCRIPTION
# Changelog

## v0.13.0

This version introduces comprehensive summary views (weekly, monthly, yearly) with detailed drill-downs, enhanced IsoReps tracking, and various backend improvements.

### Added

*   **New Summary Views & Navigation:**
    *   **Weekly Summary:** New page (`/weeklysummary/`) displaying aggregated workout data per week (Distance, Duration, Avg. Split, Total IsoReps). Includes pagination.
    *   **Monthly Summary:** New page (`/monthlysummary/`) displaying aggregated workout data per month. Includes pagination.
    *   **Yearly Summary:** New page (`/yearlysummary/`) displaying aggregated workout data per year. Includes pagination.
    *   Sidebar navigation links updated for new Weekly, Monthly, and Yearly summary pages.

*   **Detailed Breakdown Views:**
    *   **Workouts by Week (`/workouts/week/<year-week>`):**
        *   Accessible via "Details" link from the Weekly Summary page.
        *   Displays an overall summary for the selected week.
        *   Lists daily summaries for each day within that week (including days with no workouts), with links to their respective "Workouts by Date" pages.
    *   **Workouts by Month (`/workouts/month/<year-month>`):**
        *   Accessible via "Details" link from the Monthly Summary page.
        *   Displays an overall summary for the selected month.
        *   Lists weekly summaries for all weeks overlapping the month (including weeks with no workouts), with links to their "Workouts by Week" pages.
        *   Lists daily summaries for each day within the month (including days with no workouts), with links to their "Workouts by Date" pages.
    *   **Workouts by Year (`/workouts/year/<year>`):**
        *   Accessible via "Details" link from the Yearly Summary page.
        *   Displays an overall summary for the selected year.
        *   Lists monthly summaries for the year (including months with no workouts), with links to their "Workouts by Month" pages.
        *   Lists weekly summaries for all weeks overlapping the year (including weeks with no workouts), with links to their "Workouts by Week" pages.

*   **IsoReps Tracking & Display:**
    *   `total_isoreps` field added to the `Workout` model.
    *   All materialized views (`mv_day_totals`, `mv_week_totals`, `mv_month_totals`, `mv_year_totals`, `mv_sum_totals`) now calculate and store `total_isoreps_sum`.
    *   Total IsoReps are now displayed in:
        *   Daily, Weekly, Monthly, and Yearly summary tables.
        *   Detailed breakdown views for weeks, months, and years.
        *   The daily summary section on the "Workouts by Date" page (conditionally, if > 0).

*   **Backend & Structure:**
    *   New view modules created: `weeklysummary.py`, `monthlysummary.py`, `yearlysummary.py`, `workouts_by_week.py`, `workouts_by_month.py`, `workouts_by_year.py`.
    *   Routes for all new views registered in `app.py`.
    *   Added descriptive comments to route registrations in `app.py`.

### Changed

*   **Daily Summary (`/dailysummary/`):**
    *   Refactored to use the shared `CustomPagination` class from `utils.py`.
    *   Table updated to include the "Total IsoReps" column.
*   **Workouts by Date (`/workouts/date/<date>`):**
    *   The day's summary section now includes "Total IsoReps" (displayed only if value is greater than 0).
*   **Weekly Summary (`/weeklysummary/`):**
    *   "Start Date" column removed from the main table.
    *   "Actions" column added with a "Details" link to the new "Workouts by Week" page.
*   **Database Management (`database_management.py`):**
    *   Materialized view definitions updated to include `total_isoreps_sum`.
    *   The trigger function `refresh_rowing_summary_mvs` now refreshes all summary materialized views, including those with IsoReps.